### PR TITLE
[WIP] add docker-compose for local deployments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ def otaPlusProject(name: String): Project = Project(name, file(name))
         Tests.Argument(TestFrameworks.ScalaTest, "-oDF"))
     )
     .settings(testFrameworks := Seq(sbt.TestFrameworks.ScalaTest))
+    .settings(Packaging.settings)
 
 lazy val sotaCommon = otaPlusProject("common")
     .settings(libraryDependencies ++= Seq(

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,15 +43,14 @@ services:
       - db
     environment:
       HOST: '0.0.0.0'
-      SOTA_SERVICES_URI: 'http://core:8080/rvi'
       CORE_DB_URL: 'jdbc:mariadb://db:3306/sota_core'
       RESOLVER_API_URI: 'http://resolver:8081'
       CORE_INTERACTION_PROTOCOL: 'none'
 
   web:
-    image: advancedtelematic/sota-webserver
+    image: advancedtelematic/ota-plus-web
     ports:
-      - '9000:9000'
+      - '8000:9000'
     depends_on:
       - core
       - resolver

--- a/project/Packaging.scala
+++ b/project/Packaging.scala
@@ -1,3 +1,5 @@
+import sbt._
+
 object Packaging {
   import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
   import com.typesafe.sbt.packager.docker.DockerPlugin
@@ -8,7 +10,7 @@ object Packaging {
 
   lazy val settings = Seq(
     dockerRepository in Docker := Some("advancedtelematic"),
-    packageName in Docker := "sota-" + packageName.value,
+    packageName in Docker := "ota-plus-web",
     dockerBaseImage := "advancedtelematic/java:openjdk-8-jre",
     version in Docker := git.gitDescribedVersion.value.get,
     dockerUpdateLatest in Docker := true


### PR DESCRIPTION
- run with `docker-compose up`
- starts all dependent services:
  mariadb,
  resolver (from rvi_sota_server),
  core (from rvi_sota_server),
  migration,
  web-server (from rvi_sota_server?);
  and expose opened ports to localhost for local dev/test
- use only for local dev! (or change secret)
