### PR TITLE
Revert "Use play 2.5.0"

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
@@ -14,7 +14,6 @@ import play.api.Play.current
 import play.api._
 import play.api.data.Forms._
 import play.api.data._
-import play.api.http.HttpEntity
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.ws._
@@ -61,7 +60,7 @@ class Application @Inject() (ws: WSClient, val messagesApi: MessagesApi, val acc
     def toWsHeaders(hdrs: Headers) = hdrs.toMap.map {
       case(name, value) => name -> value.mkString }
 
-    val w = ws.url(apiUri + req.path)
+    val w = WS.url(apiUri + req.path)
       .withFollowRedirects(false)
       .withMethod(req.method)
       .withHeaders(toWsHeaders(req.headers).toSeq :_*)
@@ -74,8 +73,7 @@ class Application @Inject() (ws: WSClient, val messagesApi: MessagesApi, val acc
     wreq.execute.map { resp =>
       Result(
         header = ResponseHeader(resp.status, resp.allHeaders.mapValues(x => x.head)),
-        body = HttpEntity.Strict(resp.bodyAsBytes, None)
-      )
+        body = Enumerator(resp.bodyAsBytes))
     }
   }
 

--- a/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
@@ -3,7 +3,7 @@ package org.genivi.webserver.controllers
 import javax.inject.Inject
 
 import com.advancedtelematic.ota.vehicle.Vehicle
-import org.asynchttpclient.uri.Uri
+import com.ning.http.client.uri.Uri
 import play.api.{Logger, Play}
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.ws.{WSClient, WSResponseHeaders}

--- a/ota-plus-web/test/APIFunTests.scala
+++ b/ota-plus-web/test/APIFunTests.scala
@@ -7,8 +7,8 @@ import java.io.File
 import java.security.InvalidParameterException
 import java.util.UUID
 
-import org.asynchttpclient.AsyncHttpClient
-import org.asynchttpclient.request.body.multipart.FilePart
+import com.ning.http.client.AsyncHttpClient
+import com.ning.http.client.multipart.FilePart
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.scalatest.Tag
@@ -18,7 +18,7 @@ import play.api.Play
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.ws.{WS, WSResponse}
+import play.api.libs.ws.{WSResponse, WS}
 import play.api.mvc.{Cookie, Cookies}
 import play.api.test.Helpers._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
   "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
-addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.5.0")
+addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.4.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
 


### PR DESCRIPTION
This reverts commit afceb2ce0224c7aba1fdba3ed1de7fe74d685de6.

Ticket: https://advancedtelematic.atlassian.net/browse/PRO-146

Dealing with all the runtime incompatibilties (see ticket) is going to take time. In the meantime, let's get back to a working version of ota-plus-web.
