### PR TITLE
PRO-157 First batch, updating tests to Play 2.5 and enabling debug of cloud instance

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
@@ -23,6 +23,10 @@ class ClientSdkController @Inject() (system: ActorSystem,
   import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
   val logger = Logger(this.getClass)
+  private def logDebug(caller: String, msg: String) {
+    // Useful to debug instances running in the cloud.
+    logger.debug(s"[ClientSdkController.$caller()] $msg")
+  }
 
   private[this] object ConfigParameterNotFound extends Throwable with NoStackTrace
   private[this] object ConfigAuthPlusHostNotFound extends Throwable with NoStackTrace
@@ -37,6 +41,7 @@ class ClientSdkController @Inject() (system: ActorSystem,
     */
   def downloadClientSdk(vin: Vehicle.Vin, packfmt: PackageType, arch: Architecture) : Action[AnyContent] =
     Action.async { implicit request =>
+      logDebug("downloadClientSdk", s"Params: ${vin.get}-$packfmt-$arch.${packfmt.fileExtension}")
       for (
         vMetadataOpt <- vehiclesStore.getVehicle(vin);
         vMetadata <- vMetadataOpt match {

--- a/ota-plus-web/conf/logback.xml
+++ b/ota-plus-web/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
     
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/ota-plus-web/test/ApplicationSpec.scala
+++ b/ota-plus-web/test/ApplicationSpec.scala
@@ -5,7 +5,7 @@
 
 import play.api.test.Helpers._
 import org.scalatestplus.play._
-import play.api.libs.ws.WS
+import play.api.libs.ws.{WSClient, WS}
 
 /**
  * Test the Application controller
@@ -13,12 +13,14 @@ import play.api.libs.ws.WS
 class ApplicationSpec extends PlaySpec with OneServerPerSuite {
 
   "send 404 on a bad request" in {
-    val response = await(WS.url(s"http://localhost:$port/invalid").get())
+    val wsClient = app.injector.instanceOf[WSClient]
+    val response = await(wsClient.url(s"http://localhost:$port/invalid").get())
     response.status mustBe NOT_FOUND
   }
 
   "render the index page" in {
-    val response = await(WS.url(s"http://localhost:$port/").get())
+    val wsClient = app.injector.instanceOf[WSClient]
+    val response = await(wsClient.url(s"http://localhost:$port/").get())
     response.status mustBe OK
   }
 

--- a/ota-plus-web/test/com/advancedtelematic/ota/ClientSdkControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/ota/ClientSdkControllerSpec.scala
@@ -2,8 +2,8 @@ package com.advancedtelematic.ota
 
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
-import play.api.http.Status
-import play.api.libs.ws.WSClient
+import play.api.http.{HttpEntity, Status}
+import play.api.libs.ws.{WSRequest, WSClient}
 
 class ClientSdkControllerSpec extends PlaySpec
     with OneServerPerSuite
@@ -18,8 +18,16 @@ class ClientSdkControllerSpec extends PlaySpec
     val wsClient = app.injector.instanceOf[WSClient]
     forAll (minSuccessful(attempts)) {
       (vin: com.advancedtelematic.ota.vehicle.Vehicle.Vin, packfmt: PackageType, arch: Architecture) =>
-        val webappLink = s"client/${vin.get}/${packfmt.fileExtension}/${arch.toString}"
-        val fileResponse = await(wsClient.url(s"http://localhost:$port/api/v1/$webappLink").get())
+
+        def fullUri(suffix: String): WSRequest = {
+          wsClient.url(s"http://localhost:$port/api/v1/$suffix")
+        }
+        // Step 1: Register Vin
+        val webappRegistrationLink = s"vehicles/${vin.get}"
+        val registrationResponse = await(fullUri(webappRegistrationLink).put(""))
+        // Step 2: Request preconf client
+        val webappDownloadLink = s"client/${vin.get}/${packfmt.fileExtension}/${arch.toString}"
+        val fileResponse = await(fullUri(webappDownloadLink).get)
         fileResponse.status mustBe Status.OK
     }
   }


### PR DESCRIPTION
Situation:
- ticket https://advancedtelematic.atlassian.net/browse/PRO-157 is focused on bringing `ota-plus-web` tests back to life, the first commits worked towards that goal
- in parallel, it became clear that the logging removed in https://github.com/advancedtelematic/ota-plus-server/commit/872f78e4b26e5ed7026ad2cf49abebdf6d17ec91 is needed (and then some) to gain insight into our shiny new cloud-hosted web-app (in particular when it runs locally but not in-the-cloud)

Follow up PRs will deal with the rest of PRO-157 but the logging is equally necessary.
