### PR TITLE
(a) remove logging for debugging, (b) more flexible config for build service

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
@@ -40,11 +40,6 @@ class Application @Inject() (ws: WSClient,
   val coreApiUri = conf.getString("core.api.uri").get
   val resolverApiUri = conf.getString("resolver.api.uri").get
 
-  logToAudit("ENVVAR for core.api.uri", coreApiUri)
-  logToAudit("ENVVAR for resolver.api.uri", resolverApiUri)
-  logToAudit("ENVVAR for authplus.host", conf.getString("authplus.host").get)
-  logToAudit("ENVVAR for buildservice.api.uri", conf.getString("buildservice.api.uri").get)
-
   /**
    * Returns an Option[String] of the uri of the service to proxy to
    *

--- a/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
@@ -73,8 +73,12 @@ class ClientSdkController @Inject() (system: ActorSystem,
       replacements.foldLeft(uri) { case (res: String, fromTo: (String, String)) => res.replace(fromTo._1, fromTo._2) }
     }
 
-    conf.getString("buildservice.api.uri")
-      .map( placedholderFiller )
+    val buildserviceEndpoint = for (
+      host <- conf.getString("buildservice.api.host");
+      query <- conf.getString("buildservice.api.query").map( placedholderFiller )
+    ) yield host + query;
+
+    buildserviceEndpoint
       .map( url => Try(Uri.create(url)) )
       .getOrElse( Failure(ConfigParameterNotFound) )
   }

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -49,9 +49,11 @@ core.api.uri = "http://localhost:8080"
 core.api.uri = ${?CORE_API_URI}
 resolver.api.uri = "http://localhost:8081"
 resolver.api.uri = ${?RESOLVER_API_URI}
+buildservice.api.host = "http://localhost:9200"
+buildservice.api.host = ${?BUILDSERVICE_API_HOST}
 # placeholders to be supplied by the app: [vin] , [packagetype] , [arch] , [client_id] , [secret]
-buildservice.api.uri = "http://localhost:9200/api/build/[vin]?client_id=[client_id]&secret=[secret]"
-buildservice.api.uri = ${?BUILDSERVICE_API_URI}
+buildservice.api.query = "/api/build/[vin]?client_id=[client_id]&secret=[secret]"
+buildservice.api.query = ${?BUILDSERVICE_API_QUERY}
 authplus.host = "http://localhost:9001"
 authplus.host = ${?AUTHPLUS_HOST}
 


### PR DESCRIPTION
- Ticket for the logging part: https://advancedtelematic.atlassian.net/browse/PRO-181
- Part (b) simplifies updating env vars via the marathon UI. Now that dedicated vars exist (for host on the one hand; and path-query-params on the other), changes to one need not touch the value for the other.
