### PR TITLE
add docker-compose for local deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-# GENIVI SOTA Project
+# OTA Plus
 
-This project is the top-level git repository for the GENIVI SOTA project.
+To quickly get a dev system up and running, use docker-compose:
 
-Please refer to [the documentation](http://advancedtelematic.github.io/rvi_sota_server/) for more information.
+```
+cd docker
+docker-compose -f common.yml -f precise.yml up
+```
+
+You can edit `precise.yml` with the particular image tags you want.
+Wait until the migrations have finished running before you actually use the
+server.
+
+Once everything is loaded, the OTA Plus admin GUI will be available at
+`{docker-host}:8000`.

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,0 +1,57 @@
+version: '2'
+services:
+  db:
+    image: advancedtelematic/mariadb:$DEFAULT_VERSION
+    expose:
+      - '3306'
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: 'sota_test'
+      MYSQL_USER: 'sota'
+      MYSQL_PASSWORD: 's0ta'
+      MYSQL_DATABASES: 'sota_resolver sota_resolver_test sota_core sota_core_test'
+
+  resolver:
+    image: advancedtelematic/sota-resolver:$DEFAULT_VERSION
+    expose:
+      - '8081'
+    ports:
+      - '8081:8081'
+    depends_on:
+      - db
+    environment:
+      HOST: '0.0.0.0'
+      RESOLVER_DB_URL: 'jdbc:mariadb://db:3306/sota_resolver'
+      RESOLVER_DB_MIGRATE: 'true'
+
+  core:
+    image: advancedtelematic/sota-core:$DEFAULT_VERSION
+    expose:
+      - '8080'
+    ports:
+      - '8080:8080'
+    depends_on:
+      - resolver
+      - db
+    environment:
+      HOST: '0.0.0.0'
+      CORE_DB_URL: 'jdbc:mariadb://db:3306/sota_core'
+      CORE_DB_MIGRATE: 'true'
+      RESOLVER_API_URI: 'http://resolver:8081'
+      CORE_INTERACTION_PROTOCOL: 'none'
+
+  web:
+    image: advancedtelematic/ota-plus-web:$DEFAULT_VERSION
+    ports:
+      - '8000:9000'
+    depends_on:
+      - core
+      - resolver
+    environment:
+      CORE_API_URI: 'http://core:8080'
+      RESOLVER_API_URI: 'http://resolver:8081'
+      PLAY_CRYPTO_SECRET: 'secret' # only for local dev!
+
+  auth-plus:
+    image: advancedtelematic/auth-plus:$DEFAULT_VERSION

--- a/docker/precise.yml
+++ b/docker/precise.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  db:
+    image: advancedtelematic/mariadb:stable
+  resolver:
+    image: advancedtelematic/sota-resolver:52-feat_configurable-rvi-dependency-2-668ffb2336b2404de69721a16026e69f8f903f4c
+  core:
+    image: advancedtelematic/sota-core:52-feat_configurable-rvi-dependency-2-668ffb2336b2404de69721a16026e69f8f903f4c
+  web:
+    image: advancedtelematic/ota-plus-web:9-master-44dff90f4e88a6659826ee32215a5f26ea74b4c3
+  auth-plus:
+    image: advancedtelematic/auth-plus:0.3.0


### PR DESCRIPTION
- run with `DEFAULT_VERSION=stable docker-compose -f common.yml up`
- alternatively, run with `docker-compose -f common.yml -f precise.yml
  up` for containers with precise versions
- start all dependent services:
  mariadb,
  resolver (from rvi_sota_server),
  core (from rvi_sota_server),
  ota-plus-web,
  auth-plus;
  and expose opened ports to localhost for local dev/test
