### PR TITLE
PRO-182 remove leading, trailing quotation marks from value of client…

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
@@ -3,9 +3,10 @@ package org.genivi.webserver.controllers
 import javax.inject.{Inject, Named, Singleton}
 
 import akka.actor.{ActorRef, ActorSystem}
-import com.advancedtelematic.ota.vehicle.{Vehicles, Vehicle, VehicleMetadata}
+import com.advancedtelematic.ota.vehicle.{Vehicle, VehicleMetadata, Vehicles}
 import org.asynchttpclient.uri.Uri
 import play.api.http.HttpEntity
+import play.api.libs.json.JsString
 import play.api.{Configuration, Logger}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -96,8 +97,8 @@ class ClientSdkController @Inject() (system: ActorSystem,
         w.execute flatMap { wresp =>
           val t2: Try[String] = for (
             parsed <- Try( wresp.json );
-            secret <- Try( (parsed \ "client_secret").get )
-          ) yield secret.toString()
+            secret <- Try( (parsed \ "client_secret").validate[String].get )
+          ) yield secret
           Future.fromTry(t2)
         }
     }

--- a/ota-plus-web/test/APIFunTests.scala
+++ b/ota-plus-web/test/APIFunTests.scala
@@ -27,7 +27,8 @@ object APITests extends Tag("APITests")
 /**
  * Integration tests for the API
  *
- * These tests assume a blank, migrated database, as well as a webserver running on port 80
+ * These tests assume a blank, migrated database, as well as a local webserver running on the port
+ * given by test.webserver.port
  */
 class APIFunTests @Inject() (wsClient: WSClient)
   extends PlaySpec with OneServerPerSuite with GeneratorDrivenPropertyChecks {

--- a/ota-plus-web/test/com/advancedtelematic/ota/ClientSdkControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/ota/ClientSdkControllerSpec.scala
@@ -35,6 +35,7 @@ class ClientSdkControllerSpec extends PlaySpec
         // Step 1: Register Vin
         val webappRegistrationLink = s"vehicles/${vin.get}"
         val registrationResponse = await(fullUri(webappRegistrationLink).put(""))
+        registrationResponse.status mustBe Status.NO_CONTENT
         // Step 2: Request preconf client
         val webappDownloadLink = s"client/${vin.get}/${packfmt.fileExtension}/${arch.toString}"
         val fileResponse = await(fullUri(webappDownloadLink).get)


### PR DESCRIPTION
…_secret of Auth+ response

Ticket: https://advancedtelematic.atlassian.net/browse/PRO-182

@koshelev  The test for the endpoint "Contact Auth+ to obtain `client_secret` for the given VIN", should be added to Auth+ or to ota-plus-web's `APIFunTest`?
