### PR TITLE
PRO-219 persist using cassandra

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/ota/vehicle/Vehicles.scala
+++ b/ota-plus-web/app/com/advancedtelematic/ota/vehicle/Vehicles.scala
@@ -120,7 +120,7 @@ class VehiclesModule extends AbstractModule with AkkaGuiceSupport {
   @Named("vehicles-store")
   def getVehicles(@Named("vehicle-registry") registryActor: ActorRef): Vehicles = {
     import scala.concurrent.duration._
-    Vehicles(registryActor)(1.seconds)
+    Vehicles(registryActor)(2.seconds)
   }
 
 }

--- a/ota-plus-web/build.sbt
+++ b/ota-plus-web/build.sbt
@@ -28,6 +28,7 @@ dockerExposedPorts := Seq(9000)
 libraryDependencies ++= Seq (
     Dependencies.AkkaHttp,
     Dependencies.AkkaPersistence,
+    Dependencies.CassandraForAkkaPersistence,
     Dependencies.AkkaTestKit,
     "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0",
     "org.webjars" %% "webjars-play" % "2.4.0-1",

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -72,6 +72,7 @@ akka {
   persistence {
     journal {
       plugin = "akka.persistence.journal.inmem" //"cassandra-journal"
+      plugin = ${?PERSISTENCE_JOURNAL}
     }
   }
 }
@@ -81,6 +82,37 @@ play.modules.enabled += "com.advancedtelematic.ota.vehicle.VehiclesModule"
 signup {
   secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
   secret = ${?INVITE_SECRET}
+}
+
+cassandra {
+  contact-point = "127.0.0.1"
+  contact-point = ${?CASSANDRA_CONTACT_POINT}
+}
+
+cassandra-journal {
+
+  # FQCN of the cassandra journal plugin
+  class = "akka.persistence.cassandra.journal.CassandraJournal"
+
+  # Comma-separated list of contact points in the cluster.
+  # Host:Port pairs are also supported. In that case the port parameter will be ignored.
+  contact-points = [${cassandra.contact-point}, ${?CASSANDRA_CONTACT_POINT_1}, ${?CASSANDRA_CONTACT_POINT_2}]
+
+  # Name of the keyspace to be created/used by the journal
+  keyspace = "ota_plus_web_journal"
+}
+
+cassandra-snapshot-store {
+
+  # FQCN of the cassandra snapshot store plugin
+  class = "akka.persistence.cassandra.snapshot.CassandraSnapshotStore"
+
+  # Comma-separated list of contact points in the cluster.
+  # Host:Port pairs are also supported. In that case the port parameter will be ignored.
+  contact-points = [${cassandra.contact-point}, ${?CASSANDRA_CONTACT_POINT_1}, ${?CASSANDRA_CONTACT_POINT_2}]
+
+  # Name of the keyspace to be created/used by the snapshot store
+  keyspace = "ota_plus_web_snapshot"
 }
 
 # You can disable evolutions for a specific datasource if necessary

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,10 @@ object Version {
   val JsonWebSecurity = "0.2.1"
   val MockWs = "2.5.0"
   val GeniviSota = "0.1.7"
+  // Version 0.11 of akka-persistence-cassandra depends on Akka 2.4.2 and Scala 2.11.6.
+  // It is compatible with Cassandra 3.0.0 or higher
+  // Details at https://github.com/akka/akka-persistence-cassandra
+  val AkkaCassandra = "0.11"
 }
 
 object Dependencies {
@@ -25,7 +29,7 @@ object Dependencies {
 
   val AkkaTestKit = "com.typesafe.akka" %% "akka-testkit" % Version.Akka % "test"
 
-//  lazy val Scalaz = "org.scalaz" %% "scalaz-core" % "7.1.3"
+  lazy val CassandraForAkkaPersistence = "com.typesafe.akka" %% "akka-persistence-cassandra" % Version.AkkaCassandra
 
   lazy val ScalaTest = "org.scalatest" % "scalatest_2.11" % "2.2.4"
 


### PR DESCRIPTION
Ticket: https://advancedtelematic.atlassian.net/browse/PRO-219
- The fix to PRO-244 ( https://github.com/advancedtelematic/ota-plus-server/pull/43 ) is needed to run this PR.
- How to check the contents of the Cassandra store:

```
docker exec -it docker_cassandra_1 cqlsh 
...
cqlsh> DESCRIBE TABLES 
cqlsh> select * from akka.messages;
```
