### PR TITLE
hotfix for Host header (likely rewritten by proxy in infra)

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
@@ -64,15 +64,8 @@ class Application @Inject() (ws: WSClient,
   private def proxyTo(apiUri: String, req: Request[RawBuffer]) : Future[Result] = {
     def toWsHeaders(hdrs: Headers): Map[String, String] = {
 
-      val localhostPruned: Headers = {
-        // Host:localhost header causes cloud webapp to resend to itself (PRO-188)
-        hdrs.get("Host") match {
-          case Some(v) if v.contains("localhost") || v.contains("127.0.0.1") => hdrs.remove("Host")
-          case _ => hdrs
-        }
-      }
-
-      localhostPruned.toMap.map {
+      // PRO-188. Temporary fix: remove "Host" header, which trips the infrastructure.
+      hdrs.remove("Host").toMap.map {
         case(name, values) => name -> values.head
       }
     }


### PR DESCRIPTION
This PR restores the behaviour before https://github.com/advancedtelematic/ota-plus-server/pull/41 was merged.
- For some reason, the presence of a `Host` header (irrespective of its value) makes the sender receive a Service Unavailable. 
- Guessing: that header gets rewritten by some proxy, and the reply is sent to someone different from the original sender.
- the above occurs whether the "sender" is the (cloud-based) web app, or curl from the container for the (cloud-based) web-app.
