### PR TITLE
PRO-223 changed API request endpoint for creating package campaign for vehicle

### DIFF
--- a/ota-plus-web/app/assets/javascripts/components/packages/list-of-associated-packages.jsx
+++ b/ota-plus-web/app/assets/javascripts/components/packages/list-of-associated-packages.jsx
@@ -55,7 +55,12 @@ define(function(require) {
     installPackage: function(packageName, packageVersion, e) {
       e.preventDefault();
       
-      sendRequest.doPut('/api/v1/vehicles/' + this.props.SelectedVin + "/package/" + packageName + "/" + packageVersion)
+      var data = { 
+        name: packageName,
+        version: packageVersion
+      };
+      
+      sendRequest.doPost('/api/v1/updates/' + this.props.SelectedVin, data)
         .success(_.bind(function() {
            this.setState({refreshData: true});
         }, this));


### PR DESCRIPTION
Now API call used for creating new package campaign for vehicle is:

POST /api/v1/updates/:vin
{"name":"pkg", "version":"1.0.0"}
