### PR TITLE
grant_types when asking Auth+ to register VIN

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
@@ -153,7 +153,9 @@ class Application @Inject() (ws: WSClient,
         val w =
           ws.url(clientUrl).withFollowRedirects(false)
           .withMethod("POST")
-          .withBody(Json.parse("{}"))
+          .withBody(Json.parse(
+            s"""{ "grant_types": ["client_credentials"], "client_name": "${vin.get}" }"""
+          ))
 
         w.execute flatMap { wresp =>
           wresp.json.asOpt[ClientInfo] match {


### PR DESCRIPTION
- Asks for client_credentials upon registering a VIN for the first time:

```
 curl -XPOST "http://auth-plus.gw.prod01.advancedtelematic.com/clients" \
  -d '{"grant_types": ["client_credentials"], "client_name": "123456ZZZ01234569" }'
```
