### PR TITLE
Increase buffer to 200MB

### DIFF
--- a/ota-plus-core/src/main/resources/application.conf
+++ b/ota-plus-core/src/main/resources/application.conf
@@ -45,3 +45,5 @@ database = {
   migrate = false
   migrate = ${?CORE_DB_MIGRATE}
 }
+
+akka.http.parsing.max-content-length=200MB

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -78,6 +78,9 @@ akka {
 
 play.modules.enabled += "com.advancedtelematic.ota.vehicle.VehiclesModule"
 
+play.http.parser.maxDiskBuffer=200MB
+parsers.anyContent.maxLength=200MB
+
 signup {
   secret = "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
   secret = ${?INVITE_SECRET}


### PR DESCRIPTION
In Web and Core, increase buffers and max-content-length to 200MB to handle file uploads bigger than a MB or 2.
