### PR TITLE
Add new project, ota-plus-common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,14 +48,16 @@ lazy val atsRepos = Seq(
   "ATS Snapshots" at "http://nexus.prod01.internal.advancedtelematic.com:8081/content/repositories/snapshots"
 )
 
-lazy val otaPlusCore = otaPlusProject("ota-plus-core")
+lazy val otaPlusCommon = otaPlusProject("ota-plus-common")
+
+lazy val otaPlusCore = otaPlusProject("ota-plus-core").dependsOn(otaPlusCommon)
 
 lazy val otaPlusWeb = otaPlusProject("ota-plus-web")
 
-lazy val otaPlusResolver = otaPlusProject("ota-plus-resolver")
+lazy val otaPlusResolver = otaPlusProject("ota-plus-resolver").dependsOn(otaPlusCommon)
 
 lazy val rootProject = (project in file(".")).
-  aggregate(otaPlusCore, otaPlusWeb, otaPlusResolver)
+  aggregate(otaPlusCore, otaPlusWeb, otaPlusResolver, otaPlusCommon)
   .settings(Release.settings)
   .settings(publish := ())
 

--- a/ota-plus-common/build.sbt
+++ b/ota-plus-common/build.sbt
@@ -1,0 +1,10 @@
+libraryDependencies ++= Seq(
+  Dependencies.JsonWebSecurityAkka,
+  Dependencies.SotaCommonData
+) ++ Dependencies.JsonWebSecurity
+
+enablePlugins(Versioning.Plugin)
+
+Versioning.settings
+
+Release.settings

--- a/ota-plus-common/src/main/scala/com/advancedtelematic/ota/common/Namespaces.scala
+++ b/ota-plus-common/src/main/scala/com/advancedtelematic/ota/common/Namespaces.scala
@@ -1,15 +1,14 @@
-package com.advancedtelematic.ota.core
+package com.advancedtelematic.ota.common
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.{Directive1, Directives}
 import com.advancedtelematic.jws.CompactSerialization
 import com.advancedtelematic.jwt.JsonWebToken
-import eu.timepit.refined._
-import eu.timepit.refined.auto._
 import io.circe.parser._
-import org.genivi.sota.data.Namespace._
-
+import org.genivi.sota.data.Namespace.Namespace
+import eu.timepit.refined.refineV
+import eu.timepit.refined.auto._
 
 trait Namespaces {
   self: Directives =>

--- a/ota-plus-core/src/main/scala/com/advancedtelematic/ota/core/OtaCoreVehicleUpdatesResource.scala
+++ b/ota-plus-core/src/main/scala/com/advancedtelematic/ota/core/OtaCoreVehicleUpdatesResource.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.server.Directives
 import akka.stream.ActorMaterializer
 import com.advancedtelematic.akka.http.jwt.JwtDirectives._
 import com.advancedtelematic.jws.CompactSerialization
+import com.advancedtelematic.ota.common.Namespaces
 import org.genivi.sota.core.{UpdateService, VehicleUpdatesResource}
 import org.genivi.sota.core.resolver.ExternalResolverClient
 import org.genivi.sota.core.transfer.DefaultUpdateNotifier
@@ -32,7 +33,8 @@ class OtaCoreVehicleUpdatesResource(db: Database,
         }
       } ~
       (put & path("order")) { vs.setInstallOrder(vin) } ~
-      (get & pathEnd) { vs.pendingPackages(vin) } ~
+      (get & pathEnd) { vs.logVehicleSeen(vin) { vs.pendingPackages(vin) } } ~
+      (get & path("queued")) { vs.pendingPackages(vin) } ~
       (post & extractNamespace) { ns => vs.queueVehicleUpdate(ns, vin) } ~
       (get & extractUuid & path("download")) { uuid => vs.downloadPackage(vin, uuid) } ~
       (post & extractUuid) { vs.reportInstall }

--- a/ota-plus-core/src/main/scala/com/advancedtelematic/ota/core/OtaPlusCoreWebservice.scala
+++ b/ota-plus-core/src/main/scala/com/advancedtelematic/ota/core/OtaPlusCoreWebservice.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.stream.ActorMaterializer
+import com.advancedtelematic.ota.common.Namespaces
 import org.genivi.sota.core._
 import org.genivi.sota.core.resolver.{Connectivity, ExternalResolverClient}
 import org.genivi.sota.core.transfer._

--- a/ota-plus-core/src/test/scala/ExtractNamespaceSpec.scala
+++ b/ota-plus-core/src/test/scala/ExtractNamespaceSpec.scala
@@ -11,6 +11,8 @@ import com.advancedtelematic.jws.{Jws, KeyInfo}
 import com.advancedtelematic.jwt.JsonWebToken
 import com.advancedtelematic.ota.core.Generators._
 import javax.crypto.SecretKey
+
+import com.advancedtelematic.ota.common.Namespaces
 import org.genivi.sota.data.Namespace._
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks

--- a/ota-plus-resolver/src/main/scala/com/advancedtelematic/ota/resolver/OtaPlusVehiclesResource.scala
+++ b/ota-plus-resolver/src/main/scala/com/advancedtelematic/ota/resolver/OtaPlusVehiclesResource.scala
@@ -1,0 +1,39 @@
+package com.advancedtelematic.ota.resolver
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directives
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.ota.common.Namespaces
+import org.genivi.sota.resolver.vehicles.VehicleDirectives
+import slick.jdbc.JdbcBackend.Database
+
+import scala.concurrent.ExecutionContext
+
+class OtaPlusVehiclesResource(implicit system: ActorSystem,
+                              db: Database,
+                              mat: ActorMaterializer,
+                              ec: ExecutionContext) extends Directives with Namespaces {
+
+  val vs = new VehicleDirectives()
+
+  val routes = {
+    (pathPrefix("vehicles") & extractNamespace) { ns =>
+      (get & pathEnd) {
+        vs.searchVehicles(ns)
+      } ~
+        vs.extractVin { vin =>
+          (get & pathEnd) {
+            vs.getVehicle(ns, vin)
+          } ~
+            (put & pathEnd) {
+              vs.addVehicle(ns, vin)
+            } ~
+            (delete & pathEnd) {
+              vs.deleteVehicle(ns, vin)
+            } ~
+            vs.packageApi(vin) ~
+            vs.componentApi(vin)
+        }
+    }
+  }
+}

--- a/ota-plus-web/app/assets/javascripts/handlers/devices.js
+++ b/ota-plus-web/app/assets/javascripts/handlers/devices.js
@@ -66,7 +66,7 @@ define(function(require) {
               });
           break;
           case 'get-package-queue-for-vin': 
-            sendRequest.doGet('/api/v1/vehicle_updates/' + payload.vin)
+            sendRequest.doGet('/api/v1/vehicle_updates/' + payload.vin + '/queue')
               .success(function(packages) {
                 db.packageQueueForVin.reset(packages);
               });

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,8 @@
 object Version {
-
   val Akka = "2.4.4"
   val JsonWebSecurity = "0.2.1"
   val MockWs = "2.5.0"
-  val GeniviSota = "0.1.29"
+  val GeniviSota = "0.1.34"
   val GeniviResolver = GeniviSota
   // Version 0.11 of akka-persistence-cassandra depends on Akka 2.4.2 and Scala 2.11.6.
   // It is compatible with Cassandra 3.0.0 or higher


### PR DESCRIPTION
This is required to share namespace/token extraction code between
resolver and core.

Always use the same namespace when creating vins/creating vin updates

New endpoint `vehicle_updates/vin/queue` returning pending updates, but
without updating a vehicle last seen status.

Forward bearer token when forwarding requests to core/resolver
