### PR TITLE
Use `complete` instead of `reject`

### DIFF
--- a/bin/new_client.sh
+++ b/bin/new_client.sh
@@ -7,7 +7,7 @@ set -u
 
 which jq > /dev/null
 
-auth_plus_out=$(curl --silent --connect-timeout 3 -H "Content-Type: application/json" \
+auth_plus_out=$(curl --connect-timeout 3 -H "Content-Type: application/json" \
                      -X POST \
                      -d '{  "client_name": "ABC", "grant_types": ["client_credentials", "password"]  }' \
                      "$AUTHPLUS_URL/clients")

--- a/ota-plus-common/src/main/scala/com/advancedtelematic/ota/common/AuthNamespace.scala
+++ b/ota-plus-common/src/main/scala/com/advancedtelematic/ota/common/AuthNamespace.scala
@@ -1,5 +1,6 @@
 package com.advancedtelematic.ota.common
 
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive1, Directives, Rejection}
 import cats.data.Xor
@@ -11,8 +12,6 @@ import eu.timepit.refined.refineV
 
 object AuthNamespace {
   import Directives._
-
-  private[this] def badNamespaceRejection(msg: String): Rejection = AuthorizationFailedRejection
 
   private[this] def extractToken(serializedToken: String): Xor[String, JsonWebToken] =
     for {
@@ -36,7 +35,7 @@ object AuthNamespace {
       case Xor.Left(msg) =>
         extractLog flatMap { l =>
           l.info(s"Could not extract namespace: $msg")
-          reject(badNamespaceRejection(msg))
+          complete(HttpResponse(StatusCodes.Unauthorized, entity = msg))
         }
     }
   }

--- a/ota-plus-core/src/test/scala/com/advancedtelematic/ota/core/ExtractNamespaceSpec.scala
+++ b/ota-plus-core/src/test/scala/com/advancedtelematic/ota/core/ExtractNamespaceSpec.scala
@@ -38,7 +38,8 @@ class ExtractNamespaceSpec extends PropSpec
 
   property("returns an unauthorized response if namespace is not available") {
     Get("/test") ~> route ~> check {
-      rejection shouldBe a[AuthorizationFailedRejection.type]
+      status shouldBe StatusCodes.Unauthorized
+      responseAs[String] should include("No oauth token provided")
     }
   }
 }


### PR DESCRIPTION
when it's not possible to extract a namespace out of the authentication
token

This means that responses will be more readable when a client is trying
to use the api, but also means the extractor needs to be used last when
building the routes, sense the request will be completed prematurely
when calling this route and no further routes will be tried that would
not need a namespace
