### PR TITLE
Use catalog service to populate ota-plus-web secrets

### DIFF
--- a/ota-plus-web/deploy/ci.sh
+++ b/ota-plus-web/deploy/ci.sh
@@ -2,35 +2,18 @@
 set -e
 
 export JOB_NAME="${JOB_NAME-ota-plus-web}"
-
 export IMAGE_NAME="ota-plus-web"
 export REGISTRY="advancedtelematic"
 export DOCKER_TAG=`cat ../deploy/version.properties`
 export IMAGE_ARTIFACT=${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
 
-export VAULT_ENDPOINT=${VAULT_ENDPOINT-$(echo $JOB_NAME | tr "-" "_")}
-export VDATA=$(curl -s -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET ${VAULT_ADDR}/v1/secret/${VAULT_ENDPOINT})
-export PLAY_CRYPTO_SECRET="$(echo $VDATA | jq -r .data.play_crypto_secret)"
-export CORE_API_URI="$(echo $VDATA | jq -r .data.core_api_uri)"
-export RESOLVER_API_URI="$(echo $VDATA | jq -r .data.resolver_api_uri)"
-export DEVICE_REGISTRY_API_URI="$(echo $VDATA | jq -r .data.device_registry_api_uri)"
-export BUILDSERVICE_API_HOST="$(echo $VDATA | jq -r .data.buildservice_api_host)"
-export AUTHPLUS_HOST="$(echo $VDATA | jq -r .data.authplus_host)"
-export AUTHPLUS_CLIENT_ID="$(echo $VDATA | jq -r .data.authplus_client_id)"
-export AUTHPLUS_SECRET="$(echo $VDATA | jq -r .data.authplus_secret)"
-export CASSANDRA_CONTACT_POINT="$(echo $VDATA | jq -r .data.cassandra_contact_point)"
-export CASSANDRA_JOURNAL_KEYSPACE="$(echo $VDATA | jq -r .data.cassandra_journal_keyspace)"
-export AUTH0_CLIENT_ID="$(echo $VDATA | jq -r .data.auth0_client_id)"
-export AUTH0_CLIENT_SECRET="$(echo $VDATA | jq -r .data.auth0_client_secret)"
-export AUTH0_DOMAIN="$(echo $VDATA | jq -r .data.auth0_domain)"
-export AUTH0_CALLBACK_URL="$(echo $VDATA | jq -r .data.auth0_callback_url)"
-export AUTH0_USER_UPDATE_TOKEN="$(echo $VDATA | jq -r .data.auth0_user_update_token)"
-export WEB_AWS_ACCESS_KEY="$(echo $VDATA | jq -r .data.web_aws_access_key)"
-export WEB_AWS_SECRET_KEY="$(echo $VDATA | jq -r .data.web_aws_secret_key)"
-export port PORT="9000"
+# Merge service environment variables with secrets from this vault endpoint.
+export VAULT_ENDPOINT="ota_plus_web_catalog"
+export CATALOG_ADDR="http://catalog.gw.prod01.internal.advancedtelematic.com"
 
 REQ=$(envsubst < deploy/service.json)
-curl --fail -X PUT \
-  -H "Content-Type: application/json" \
-  -d "$REQ" \
-  http://marathon.prod01.internal.advancedtelematic.com:8080/v2/apps
+curl -Ssf                               \
+     -H "X-Vault-Token: ${VAULT_TOKEN}" \
+     -X POST                            \
+     -d"$REQ"                           \
+     ${CATALOG_ADDR}/service/${VAULT_ENDPOINT}

--- a/ota-plus-web/deploy/service.json
+++ b/ota-plus-web/deploy/service.json
@@ -1,4 +1,4 @@
-[{
+{
   "id": "${JOB_NAME}",
   "uris": ["/root/docker.tar.gz"],
   "cpus": 0.2,
@@ -24,24 +24,7 @@
     "SERVICE_TYPE": "http",
     "SERVICE_IMAGE": "${IMAGE_ARTIFACT}",
     "SERVICE_HEALTH_CHECK": "curl --show-error --silent %<host>s:%<port>s/health",
-    "CORE_API_URI": "${CORE_API_URI}",
-    "RESOLVER_API_URI": "${RESOLVER_API_URI}",
-    "DEVICE_REGISTRY_API_URI": "${DEVICE_REGISTRY_API_URI}",
-    "BUILDSERVICE_API_HOST": "${BUILDSERVICE_API_HOST}",
-    "CASSANDRA_CONTACT_POINT": "${CASSANDRA_CONTACT_POINT}",
-    "CASSANDRA_JOURNAL_KEYSPACE": "${CASSANDRA_JOURNAL_KEYSPACE}",
     "PERSISTENCE_JOURNAL": "cassandra-journal",
-    "AUTHPLUS_HOST": "${AUTHPLUS_HOST}",
-    "AUTHPLUS_CLIENT_ID": "${AUTHPLUS_CLIENT_ID}",
-    "AUTHPLUS_SECRET": "${AUTHPLUS_SECRET}",
-    "PLAY_CRYPTO_SECRET": "${PLAY_CRYPTO_SECRET}",
-    "AUTH0_CLIENT_ID": "${AUTH0_CLIENT_ID}",
-    "AUTH0_CLIENT_SECRET": "${AUTH0_CLIENT_SECRET}",
-    "AUTH0_DOMAIN": "${AUTH0_DOMAIN}",
-    "AUTH0_CALLBACK_URL": "${AUTH0_CALLBACK_URL}",
-    "AUTH0_USER_UPDATE_TOKEN": "${AUTH0_USER_UPDATE_TOKEN}",
-    "AWS_ACCESS_KEY_ID": "${WEB_AWS_ACCESS_KEY}",
-    "AWS_SECRET_ACCESS_KEY": "${WEB_AWS_SECRET_KEY}",
     "MESSAGING_MODE": "kinesis"
   },
   "healthChecks": [{
@@ -49,4 +32,4 @@
     "path": "/health",
     "intervalSeconds": 30
   }]
-}]
+}


### PR DESCRIPTION
We will try to use catalog service with `ota-plus-web`
- To reduce the responsibility of the `TeamCity` required to deal with vault and marathon.
- To reduce the duplication of assignments in `service.json` and `ci.sh` files.

I have updated the `VAULT_ENDPOINT` `ota_plus_web` with **capitalized** `keys` as required in marathon JSON file as it is case sensitive.

Also `service.json` now needs to be a json object `{}` not an array of json objects `[{}]` and since we don't use group-deployments in marathon now. it will be totally fine.

I hope this works well. let's see.
