### PR TITLE
[PRO-259] Use AuthPlusAccessToken instead of IdToken

### DIFF
--- a/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/Application.scala
@@ -107,8 +107,7 @@ class Application @Inject() (ws: WSClient,
       .withMethod(req.method)
       .withQueryString(req.queryString.mapValues(_.head).toSeq :_*)
       .withHeaders(toWsHeaders(req.headers).toSeq :_*)
-      .withHeaders(("Authorization", "Bearer " + req.idToken.value))
-      // TODO: Switch back to access_token after https://advancedtelematic.atlassian.net/browse/PRO-858
+      .withHeaders(("Authorization", "Bearer " + req.authPlusAccessToken.value))
 
     val wreq = req.body.asBytes() match {
       case Some(b) => w.withBody(b)

--- a/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/ClientSdkController.scala
@@ -70,7 +70,7 @@ extends Controller with ApiClientSupport {
   def downloadClientSdk(device: Uuid, artifact: ArtifactType, arch: Architecture) : Action[AnyContent] =
     AuthenticatedApiAction.async { implicit request =>
       for (
-        dev <- devicesApi.getDevice(UserOptions(Some(request.idToken.value)), device);
+        dev <- devicesApi.getDevice(UserOptions(Some(request.authPlusAccessToken.value)), device);
         vMetadata <- getRegisterDevice(device) if dev.namespace == request.namespace;
         secret <- authPlusApi.fetchSecret(vMetadata.clientInfo.clientId);
         result <- preconfClient(vMetadata.uuid, artifact, arch, vMetadata.clientInfo.clientId, secret)

--- a/ota-plus-web/app/org/genivi/webserver/controllers/DeviceController.scala
+++ b/ota-plus-web/app/org/genivi/webserver/controllers/DeviceController.scala
@@ -43,7 +43,7 @@ extends Controller with ApiClientSupport {
 
   private[this] def userOptions(req: AuthenticatedRequest[_]): UserOptions = {
     val traceId = req.headers.get("x-ats-traceid")
-    UserOptions(Some(req.idToken.value), traceId, Some(req.namespace))
+    UserOptions(Some(req.authPlusAccessToken.value), traceId, Some(req.namespace))
   }
 
   /**


### PR DESCRIPTION
So core is going to start verifying the tokens sent to it (either locally or using auth+) so OTA+ should send the Auth+ accesstoken rather than the idtoken.
