### PR TITLE
[PRO-1358] Each Ota+ instance gets its own groupId

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/ota/Messages/WebMessageBusListenerActor.scala
+++ b/ota-plus-web/app/com/advancedtelematic/ota/Messages/WebMessageBusListenerActor.scala
@@ -2,6 +2,8 @@ package com.advancedtelematic.ota.Messages
 
 import akka.actor.{ActorSystem, Props}
 import cats.data.Xor
+import com.typesafe.config.ConfigValueFactory
+import java.util.UUID
 import org.genivi.sota.messaging.MessageBus
 import org.genivi.sota.messaging.Messages.{BusMessage, MessageLike}
 import org.genivi.sota.messaging.daemon.MessageBusListenerActor
@@ -11,9 +13,14 @@ import scala.reflect.runtime.universe._
 
 object WebMessageBusListenerActor {
   val _log = LoggerFactory.getLogger(this.getClass)
+  val uuid = UUID.randomUUID()
 
   def props[M <: BusMessage]()(implicit ml: MessageLike[M], tt: TypeTag[M], system: ActorSystem): Props = {
-    val source = MessageBus.subscribe(system, system.settings.config) match {
+    val groupIdPrefix = system.settings.config.getString("messaging.kafka.groupIdPrefix")
+    val newGroupIdPrefix = ConfigValueFactory.fromAnyRef(groupIdPrefix + s"-$uuid-")
+    val config = system.settings.config.withValue("messaging.kafka.groupIdPrefix", newGroupIdPrefix)
+
+    val source = MessageBus.subscribe(system, config) match {
       case Xor.Right(s) =>
         s.map { msg =>
           _log.info(s"Received ${ml.streamName} -> ${ml.id(msg)}, publishing to akka event stream")


### PR DESCRIPTION
The changes to `docker/start-ota-plus-web.sh` is to get CI to work since auth-plus recently changed default envs.