### PR TITLE
Move Auth0 specific logout functionality to server

### DIFF
--- a/ota-plus-web/app/reactapp/src/utils/Common.jsx
+++ b/ota-plus-web/app/reactapp/src/utils/Common.jsx
@@ -1,6 +1,4 @@
 const doLogout = () => {
-  document.getElementById('logout-return-to').value =
-    location.protocol + '//' + location.host + '/logout';
   document.getElementById('logout').submit();
 }
 

--- a/ota-plus-web/app/views/main.scala.html
+++ b/ota-plus-web/app/views/main.scala.html
@@ -11,10 +11,7 @@
     <link href="/assets/css/style.css" rel="stylesheet" type="text/css"/>
   </head>
   <body>
-    <form id="logout" action="https://@{config.domain}/v2/logout">
-      <input type="hidden" name="client_id" value="@{config.clientId}" />
-      <input type="hidden" id="logout-return-to" name="returnTo" value="http://localhost:9000/logout" />
-    </form>
+    <form id="logout" action="/logout"/>
     <input type="hidden" id="csrf-token-val" value="@csrf.get.value"/>
     <input type="hidden" id="ws-url" value="@wsUrl"/>
     <input type="hidden" id="toggle-atsGarageTheme" value="@{uiToggles.atsGarageTheme}"/>


### PR DESCRIPTION
Integration of OIDC providers other then Auth0 is problematic
if logout functionality in ui explicitly calls Auth0. This change
should allow to implement provider-specific logout actions.

Resolves: PRO-4984