### PR TITLE
Use Circe to serialize keyType

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/controllers/PathBinders.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/PathBinders.scala
@@ -7,7 +7,7 @@ package com.advancedtelematic.controllers
 
 import com.advancedtelematic.api.ApiVersion
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.libtuf.data.TufDataType.{EdKeyType, RsaKeyType}
+import com.advancedtelematic.libtuf.data.TufDataType.{EcPrime256KeyType, Ed25519KeyType, RsaKeyType}
 import play.api.mvc.{PathBindable, QueryStringBindable}
 
 /**
@@ -56,7 +56,8 @@ object PathBinders {
       params.get(key).flatMap(_.headOption).map { p =>
         p.toLowerCase match {
           case "rsa" => Right(RsaKeyType)
-          case "ed25519" => Right(EdKeyType)
+          case "ed25519" => Right(Ed25519KeyType)
+          case "ecprime256v1" => Right(EcPrime256KeyType)
           case _ => Left("unknown key type")
         }
       }
@@ -64,7 +65,8 @@ object PathBinders {
     def unbind(key: String, value: KeyType): String = {
       val kt = value match {
         case RsaKeyType => "rsa"
-        case EdKeyType => "ed25519"
+        case Ed25519KeyType => "ed25519"
+        case EcPrime256KeyType => "ecprime256v1"
       }
 
       key + "=" + kt

--- a/ota-plus-web/build.sbt
+++ b/ota-plus-web/build.sbt
@@ -40,6 +40,7 @@ libraryDependencies ++= Seq(
   guice,
   cacheApi,
   Dependencies.LibTuf,
+  Dependencies.LibTufServer,
   Dependencies.jose4j
 ) ++
 Dependencies.TestFrameworks ++

--- a/ota-plus-web/test/com/advancedtelematic/api/ApiClientTest.scala
+++ b/ota-plus-web/test/com/advancedtelematic/api/ApiClientTest.scala
@@ -1,0 +1,16 @@
+package com.advancedtelematic.api
+
+import io.circe.Json
+import org.scalatest.FunSuite
+import play.api.libs.ws.InMemoryBody
+
+class ApiClientTest extends FunSuite with CirceJsonBodyWritables {
+
+  test("circeJsonBodyWritable") {
+    val json = Json.obj("k" -> Json.fromInt(17))
+    val wsBody = circeJsonBodyWritable.transform(json)
+    val inMem = wsBody.asInstanceOf[InMemoryBody]
+    assert(inMem.bytes.utf8String == """{"k":17}""")
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,9 @@
 object Version {
-  val Akka = "2.5.8"
+  val Akka = "2.5.9"
   val JsonWebSecurity = "0.4.5"
   val MockWs = "2.6.2"
   val LibAts = "0.1.0-5-g6b585f0"
-  val LibTuf = "0.2.0-44-gda9b1e2"
+  val LibTuf = "0.4.0-10-ge535619"
   val Netty = "4.1.19.Final"
   val ScalaCheck = "1.13.4"
   val ScalaTestPlay = "3.1.2"
@@ -29,6 +29,7 @@ object Dependencies {
   ).map(_ % Version.LibAts)
 
   lazy val LibTuf = "com.advancedtelematic" %% "libtuf" % Version.LibTuf
+  lazy val LibTufServer = "com.advancedtelematic" %% "libtuf-server" % Version.LibTuf
 
   val Netty = Set("io.netty" % "netty-handler", "io.netty" % "netty-codec").map(_ % Version.Netty)
 }


### PR DESCRIPTION
Error was that the key type was sent as `{"keyType":"\"RSA\""}` to the services. Added Play thingie to be able to use a circe encoder. Tested on Oslo.