### PR TITLE
Return 404 when credentials are not found in crypt

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/CryptApi.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/CryptApi.scala
@@ -118,6 +118,8 @@ class CryptApi(conf: Configuration, val apiExec: ApiClientExec)(implicit exec: E
       .transform {
         case Success(res) if Status.isServerError(res.header.status) =>
                             Failure(RemoteApiError(res, "vault error status"))
+        case Success(res) if ! Status.isSuccessful(res.header.status) =>
+          Failure(RemoteApiError(res, s"Error status ${res.header.status} downloading credentials"))
         case Success(res) => Success(res.body)
         case Failure(exception) => Failure(exception)
       }


### PR DESCRIPTION

ota-app was returning valid credentials.zip with invalid autoprov certificate when downloading credentials from another user (hats)

This happens in hat environments. The credentials.zip is still downloaded, but contains 0 length autoprov pkcs12 file.
