### PR TITLE
Fix an issue where we cant create a new user

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/auth/garage/NoLoginAction.scala
+++ b/ota-plus-web/app/com/advancedtelematic/auth/garage/NoLoginAction.scala
@@ -6,8 +6,9 @@ import java.util.Base64
 
 import akka.actor.ActorSystem
 import com.advancedtelematic.PlayMessageBusPublisher
-import com.advancedtelematic.auth.{AccessTokenBuilder, IdentityClaims, IdToken, SessionCodecs}
-import com.advancedtelematic.controllers.{UserLogin, UserId}
+import com.advancedtelematic.auth.{AccessTokenBuilder, IdToken, IdentityClaims, SessionCodecs}
+import com.advancedtelematic.controllers.{UserId, UserLogin}
+import com.advancedtelematic.libats.data.DataType.Namespace
 import javax.inject.Inject
 import play.api.{Configuration, Logger}
 import play.api.libs.json.Json
@@ -60,6 +61,7 @@ class NoLoginAction @Inject()(messageBus: PlayMessageBusPublisher,
     messageBus.publishSafe(UserLogin(
         fakeNamespace,
         Some(IdentityClaims(UserId(fakeNamespace), "guest", None, email)),
+        Namespace(fakeNamespace),
         Instant.now()))
 
     Future.successful(result)

--- a/ota-plus-web/app/com/advancedtelematic/controllers/LoginController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/LoginController.scala
@@ -9,6 +9,7 @@ import com.advancedtelematic.api.UnexpectedResponse
 import com.advancedtelematic.auth.{AccessToken, IdentityClaims, IdToken, LoginAction, LogoutAction,
   OAuthConfig, SessionCodecs, TokenExchange, Tokens, UiAuthAction}
 import com.advancedtelematic.auth.oidc.{NamespaceProvider, OidcGateway}
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.MessageLike
 import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
@@ -20,7 +21,7 @@ import scala.concurrent.Future
 
 final case class LoginData(username: String, password: String)
 
-final case class UserLogin(id: String, identity: Option[IdentityClaims], timestamp: Instant)
+final case class UserLogin(id: String, identity: Option[IdentityClaims], namespace: Namespace, timestamp: Instant)
 
 object UserLogin {
 
@@ -88,13 +89,13 @@ class OAuthOidcController @Inject()(
     Redirect(routes.OAuthOidcController.authorizationError()).flashing("authzError" -> error)
   }
 
-  def publishLoginEvent(userId: UserId, accessToken: AccessToken): Future[Done] = {
+  def publishLoginEvent(userId: UserId, namespace: Namespace, accessToken: AccessToken): Future[Done] = {
     oidcGateway.getUserInfo(accessToken)
-      .map(x => UserLogin(x.userId.id, Some(x), Instant.now()))
+      .map(claim => UserLogin(claim.userId.id, Some(claim), Namespace(claim.userId.id), Instant.now()))
       .recover {
         case t =>
-          log.warn("Unble get user info", t)
-          UserLogin(userId.id, None, Instant.now())
+          log.warn("Unable to get user info", t)
+          UserLogin(userId.id, None, namespace, Instant.now())
       }
       .flatMap(x => messageBus.publish(x).map(_ => Done))
   }
@@ -113,7 +114,7 @@ class OAuthOidcController @Inject()(
         tokens                                   <- oidcGateway.exchangeCodeForTokens(code)
         newTokens @ Tokens(accessToken, idToken) <- tokenExchange.run(tokens)
         ns = namespaceProvider.apply(newTokens)
-        _ <- publishLoginEvent(idToken.userId, accessToken)
+        _ <- publishLoginEvent(idToken.userId, ns, accessToken)
       } yield
         Redirect(com.advancedtelematic.controllers.routes.Application.index()).withSession(
           "namespace"    -> ns.get,


### PR DESCRIPTION
After https://github.com/advancedtelematic/ota-plus-user-profile/pull/73 we can't create a new user because decoding the `UserLogin` event expects a new field `namespace` which is not present.