### PR TITLE
[OTA-2618] New users get a unique namespace different than the userId

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
+++ b/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
@@ -1,16 +1,41 @@
 package com.advancedtelematic.auth.oidc
 
-import javax.inject.Inject
+import akka.http.scaladsl.util.FastFuture
+import com.advancedtelematic.api.{ApiClientExec, ApiClientSupport}
 import com.advancedtelematic.auth.Tokens
 import com.advancedtelematic.libats.data.DataType.Namespace
+import javax.inject.Inject
 import play.api.Configuration
+import play.api.libs.ws.WSClient
 
-trait NamespaceProvider extends (Tokens => Namespace)
+import scala.concurrent.{ExecutionContext, Future}
+
+trait NamespaceProvider extends (Tokens => Future[Namespace])
 
 class NamespaceFromIdentity extends NamespaceProvider {
-  override def apply(tokens: Tokens): Namespace = Namespace(tokens.idToken.userId.id)
+  override def apply(tokens: Tokens): Future[Namespace] = FastFuture.successful{
+    Namespace(tokens.idToken.userId.id)
+  }
 }
 
+class NamespaceFromUserProfile @Inject()(val conf: Configuration,
+                                         val ws: WSClient,
+                                         val clientExec: ApiClientExec)
+                                        (implicit ec: ExecutionContext)
+  extends NamespaceProvider with ApiClientSupport {
+
+  override def apply(tokens: Tokens): Future[Namespace] =
+    userProfileApi.userOrganizations(tokens.idToken.userId).map {
+      case organizations if organizations.isEmpty =>
+        Namespace.generate
+      case organizations =>
+        organizations.filter(_.isCreator).map(_.namespace).head
+    }
+}
+
+
 class ConfiguredNamespace @Inject()(configuration: Configuration) extends NamespaceProvider {
-  override def apply(tokens: Tokens): Namespace = Namespace(configuration.get[String]("oidc.namespace"))
+  override def apply(tokens: Tokens): Future[Namespace] = FastFuture.successful {
+    Namespace(configuration.get[String]("oidc.namespace"))
+  }
 }

--- a/ota-plus-web/app/com/advancedtelematic/controllers/LoginController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/LoginController.scala
@@ -116,7 +116,7 @@ class OAuthOidcController @Inject()(
       val loginResult = for {
         tokens                                   <- oidcGateway.exchangeCodeForTokens(code)
         newTokens @ Tokens(accessToken, idToken) <- tokenExchange.run(tokens)
-        ns = namespaceProvider.apply(newTokens)
+        ns <- namespaceProvider(newTokens)
         _ <- publishLoginEvent(idToken.userId, ns, accessToken)
       } yield
         Redirect(com.advancedtelematic.controllers.routes.Application.index()).withSession(

--- a/ota-plus-web/app/com/advancedtelematic/controllers/NamespaceController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/NamespaceController.scala
@@ -44,4 +44,8 @@ class NamespaceController @Inject()(val conf: Configuration,
           )
       }
     }
+
+  def namespaceStatus: Action[AnyContent]= authAction.async { request =>
+    userProfileApi.getNamespaceSetupStatus(request.namespace)
+  }
 }

--- a/ota-plus-web/app/com/advancedtelematic/controllers/UserProfileController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/UserProfileController.scala
@@ -92,9 +92,8 @@ class UserProfileController @Inject()(val conf: Configuration,
   implicit val featureW: Writes[FeatureName] = Writes.StringWrites.contramap(_.get)
 
   def getFeatures(): Action[AnyContent] = authAction.async { request =>
-    val userId = request.idToken.userId
     userProfileApi
-      .getFeatures(userId)
+      .getFeatures(request.namespace)
       .map { features =>
         Ok(Json.toJson(features))
       }

--- a/ota-plus-web/app/reactapp/src/config.js
+++ b/ota-plus-web/app/reactapp/src/config.js
@@ -15,7 +15,7 @@ export const API_GET_MULTI_TARGET_UPDATE_INDENTIFIER = '/api/v1/multi_target_upd
 export const API_CREATE_MULTI_TARGET_UPDATE = '/api/v1/admin/devices';
 export const API_FETCH_MULTI_TARGET_UPDATES = '/api/v1/admin/devices';
 export const API_CANCEL_MULTI_TARGET_UPDATE = '/api/v2/cancel_device_update_campaign';
-export const API_NAMESPACE_SETUP_STEPS = '/user/setup';
+export const API_NAMESPACE_SETUP_STEPS = '/organization/setup';
 
 /*
  *  User

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -37,7 +37,7 @@ play.modules.enabled += "play.filters.csrf.CSRFModule"
 oidc {
   namespace = "default"
   namespace = ${?OIDC_NAMESPACE}
-  namespaceProvider = "com.advancedtelematic.auth.oidc.NamespaceFromIdentity"
+  namespaceProvider = "com.advancedtelematic.auth.oidc.NamespaceFromUserProfile"
   namespaceProvider = ${?OIDC_NS_PROVIDER}
   loginAction = "com.advancedtelematic.auth.garage.LoginAction"
   loginAction = ${?OIDC_LOGIN_ACTION}

--- a/ota-plus-web/conf/routes
+++ b/ota-plus-web/conf/routes
@@ -45,3 +45,4 @@ PUT     /user/*path                       com.advancedtelematic.controllers.User
 
 # Namespaces AKA organizations
 GET     /organizations/:namespace/index   com.advancedtelematic.controllers.NamespaceController.switchNamespace(namespace: com.advancedtelematic.libats.data.DataType.Namespace)
+GET     /organization/setup               com.advancedtelematic.controllers.NamespaceController.namespaceStatus

--- a/ota-plus-web/test/com/advancedtelematic/controllers/ClientToolControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/ClientToolControllerSpec.scala
@@ -49,8 +49,8 @@ class ClientToolControllerSpec extends PlaySpec with GuiceOneServerPerSuite with
   val registrationUrl = s"$CryptHost/accounts/$namespaceWithOnlineKeys/credentials/registration"
 
   val authPlusClientUrl =  s"$authPlusUri/clients/$clientId"
-  val treehubJsonUrl = s"$userProfileUri/api/v1/users/$namespaceWithOnlineKeys/features/treehub"
-  val treehubJsonOfflineUrl = s"$userProfileUri/api/v1/users/$namespaceWithOfflineKeys/features/treehub"
+  val treehubJsonUrl = s"$userProfileUri/api/v1/organizations/$namespaceWithOnlineKeys/features/treehub"
+  val treehubJsonOfflineUrl = s"$userProfileUri/api/v1/organizations/$namespaceWithOfflineKeys/features/treehub"
 
   val rootJsonUrl = s"$repoServerUri/api/v1/user_repo/root.json"
   val keyPairsUrl = s"$keyServerUri/api/v1/root/$namespaceWithOnlineKeys/keys/targets/pairs"
@@ -106,6 +106,15 @@ class ClientToolControllerSpec extends PlaySpec with GuiceOneServerPerSuite with
 
     case (GET, `keyOfflineUrl`) =>
       Action(_ => NotFound)
+
+    case (GET, url) if url.endsWith("/userinfo") =>
+      Action(_ => Ok(
+        Json.obj(
+          "email" -> "",
+          "sub" -> "",
+          "name" -> ""
+        )
+      ))
   }
 
   val mockClient = MockWS(defaultCryptRoutes orElse defaultRoutes)

--- a/ota-plus-web/test/com/advancedtelematic/controllers/GarageLoginSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/GarageLoginSpec.scala
@@ -82,6 +82,14 @@ class GarageLoginSpec extends PlaySpec with GuiceOneAppPerSuite with MockWSHelpe
       val jwks = new JsonWebKeySet(key).toJson
       Action(Ok(jwks))
 
+    case ("GET", url) if ".*/api/v1/users/.*/organizations".r.findFirstIn(url).isDefined =>
+      Action(_ => Ok(Json.arr(
+        Json.obj(
+        "namespace" -> namespace,
+        "name" -> "My Organization",
+        "isCreator" -> true
+      ))))
+
     case (method, url) =>
       Action {
         NotFound(s"No handler for ' $method $url'")

--- a/ota-plus-web/test/com/advancedtelematic/controllers/NamespaceControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/NamespaceControllerSpec.scala
@@ -25,8 +25,13 @@ class NamespaceControllerSpec extends PlaySpec
   val userAllowedNamespace = "another-namespace"
 
   val mock = MockWS {
-    case (GET, url) if s"$userProfileUri/api/v1/users/.*/namespaces".r.findFirstIn(url).isDefined =>
-      Action(_ => Ok(Json.arr(userAllowedNamespace)))
+    case (GET, url) if s"$userProfileUri/api/v1/users/.*/organizations".r.findFirstIn(url).isDefined =>
+      Action(_ => Ok(Json.arr(
+        Json.obj(
+          "namespace" -> userAllowedNamespace,
+          "name" -> "My Organization",
+          "isCreator" -> true
+        ))))
   }
 
   implicit override lazy val app: play.api.Application =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ object Version {
   val Akka = "2.5.9"
   val JsonWebSecurity = "0.4.5"
   val MockWs = "2.6.2"
-  val LibAts = "0.2.1-15-g7cd2082"
+  val LibAts = "0.2.1-17-g08f3ea9"
   val LibTuf = "0.4.0-10-ge535619"
   val Netty = "4.1.19.Final"
   val ScalaCheck = "1.13.4"
@@ -25,6 +25,7 @@ object Dependencies {
 
   lazy val jose4j = "org.bitbucket.b_c" % "jose4j" % Version.Jose4j
   val LibAts = Set(
+    "com.advancedtelematic" %% "libats",
     "com.advancedtelematic" %% "libats-messaging"
   ).map(_ % Version.LibAts)
 


### PR DESCRIPTION
Break the constraint that `userId == namespace`. When a new user logs in, we generate a unique namespace different than the userId. When an existing user logs in, we fetch the namespace from user-profile.
Should be merged and deployed with https://github.com/advancedtelematic/ota-plus-user-profile/pull/85.