### PR TITLE
[OTA-2848] Add routes to latest user-profile organizations endpoints

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
@@ -215,9 +215,10 @@ class UserProfileApi(val conf: Configuration, val apiExec: ApiClientExec) extend
   def namespaceIsAllowed(userId: UserId, namespace: Namespace)(implicit ec: ExecutionContext): Future[Boolean] =
     userOrganizations(userId).map(_.map(_.namespace)).map(_.contains(namespace))
 
-  def getNamespaceSetupStatus(namespace: Namespace): Future[Result] =
-    userProfileRequest(s"organizations/${namespace.get}/setup")
-      .transform(_.withMethod("GET"))
+  def organizationRequest(namespace: Namespace, method: String, path: String, body: Option[JsValue]): Future[Result] =
+    userProfileRequest(s"organizations/${namespace.get}/$path")
+      .transform(_.withMethod(method))
+      .transform(r => body.map(json => r.withBody(json)).getOrElse(r))
       .execResult(apiExec)
 }
 

--- a/ota-plus-web/app/com/advancedtelematic/controllers/NamespaceController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/NamespaceController.scala
@@ -45,7 +45,7 @@ class NamespaceController @Inject()(val conf: Configuration,
       }
     }
 
-  def namespaceStatus: Action[AnyContent]= authAction.async { request =>
-    userProfileApi.getNamespaceSetupStatus(request.namespace)
+  def proxyRequest(path: String): Action[AnyContent]= authAction.async { request =>
+    userProfileApi.organizationRequest(request.namespace, request.method, path, request.body.asJson)
   }
 }

--- a/ota-plus-web/conf/routes
+++ b/ota-plus-web/conf/routes
@@ -45,4 +45,5 @@ PUT     /user/*path                       com.advancedtelematic.controllers.User
 
 # Namespaces AKA organizations
 GET     /organizations/:namespace/index   com.advancedtelematic.controllers.NamespaceController.switchNamespace(namespace: com.advancedtelematic.libats.data.DataType.Namespace)
-GET     /organization/setup               com.advancedtelematic.controllers.NamespaceController.namespaceStatus
+GET     /organization/*path               com.advancedtelematic.controllers.NamespaceController.proxyRequest(path: String)
+POST    /organization/*path               com.advancedtelematic.controllers.NamespaceController.proxyRequest(path: String)


### PR DESCRIPTION
This is so that app can access the new `organization` endpoints from user-profile:

- GET /organization/setup -> GET /api/v1/organization/:current-namespace/setup
- GET /organization/tentative_users -> GET /api/v1/organization/:current-namespace/tentative_users
- POST /organization/users -> GET /api/v1/organization/:current-namespace/users