### PR TITLE
[OTA-3105] Sort device update history by eventTime field

### DIFF
--- a/ota-plus-web/app/reactapp/src/stores/SoftwareStore.js
+++ b/ota-plus-web/app/reactapp/src/stores/SoftwareStore.js
@@ -605,7 +605,7 @@ export default class SoftwareStore {
   }
 
   preparePackagesHistory() {
-    this.packagesHistory = _.sortBy(this.packagesHistory, pack => pack.receivedAt).reverse();
+    this.packagesHistory = _.sortBy(this.packagesHistory, pack => pack.eventTime).reverse();
   }
 
   enablePackageAutoInstall(targetName, deviceId, ecuSerial) {


### PR DESCRIPTION
The `receivedAt` field that was used previously exists only in the device-registry DB entry, which is not the thing that device-registry returns via the installation history endpoint.