### PR TITLE
Use -ATS suffix for tracing lib version

### DIFF
--- a/ota-plus-web/build.sbt
+++ b/ota-plus-web/build.sbt
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
   Dependencies.LibTuf,
   Dependencies.LibTufServer,
   Dependencies.jose4j,
-  "io.zipkin.brave.play" %% "play-zipkin-tracing-play" % "3.0.2-SNAPSHOT",
+  "io.zipkin.brave.play" %% "play-zipkin-tracing-play" % "3.0.2-ATS",
 ) ++
 Dependencies.TestFrameworks ++
 Dependencies.LibAts


### PR DESCRIPTION
sbt refuses to run `release` in tc if we use `-SNAPSHOT`

Signed-off-by: Simão Mata <simao.mata@here.com>