### PR TITLE
url-encode namespace in path

### DIFF
--- a/ota-plus-web/test/com/advancedtelematic/controllers/NamespaceControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/NamespaceControllerSpec.scala
@@ -23,7 +23,7 @@ class NamespaceControllerSpec extends PlaySpec
   with Results {
 
   val userProfileUri = "http://user-profile.com"
-  val userAllowedNamespace = "another-namespace"
+  val userAllowedNamespace = "another|namespace"
 
   val mock = MockWS {
     case (GET, url) if s"$userProfileUri/api/v1/users/.*/organizations".r.findFirstIn(url).isDefined =>


### PR DESCRIPTION
Namespace/organization can also come from legacy account name, so it also needs to be URL-encoded.