### PR TITLE
Fix asciidoc syntax issues to clean up warnings

### DIFF
--- a/ota-plus-web/docs/modules/ROOT/pages/_partials/devices.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/_partials/devices.adoc
@@ -3,13 +3,13 @@
 //  tag::single-device-install-steps[]
 *To install a software version on a single device, follow these steps:*
 
-1.  Navigate to the https://connect.ota.here.com/#/devices[Devices] page, select a device group, and select a device within that group.
-1.  Click the *primary ECU*, and in the *SOFTWARE* section, locate the software that you want to install, and click the software name.
+.  Navigate to the https://connect.ota.here.com/#/devices[Devices] page, select a device group, and select a device within that group.
+.  Click the *primary ECU*, and in the *SOFTWARE* section, locate the software that you want to install, and click the software name.
 * You should see a list of all applicable versions of that software.
-1.  Select the version that you want to install.
+.  Select the version that you want to install.
 * In the right-hand *PROPERTIES* panel, you'll see more details about the selected software version — the status should be *Not Installed*.
 +
-1.  Click the *Install* button at the bottom of the *PROPERTIES* section.
+.  Click the *Install* button at the bottom of the *PROPERTIES* section.
 * OTA Connect will remotely install the software version on your test device.
 
 [.thumb]

--- a/ota-plus-web/docs/modules/ROOT/pages/create-device-groups.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/create-device-groups.adoc
@@ -2,10 +2,10 @@
 
 Once enough devices have been provisioned, you should organize them into groups so that you can target them in your campaigns.
 
-There have two types of group: *fixed group* and *smart group*. 
+There have two types of group: *fixed group* and *smart group*.
 
 * The *fixed group* type is useful if you already have a fixed list of devices that you want to update.
-* The *smart group* type is useful if you know the selection criteria for devices to update but don't yet have a fixed list of devices. 
+* The *smart group* type is useful if you know the selection criteria for devices to update but don't yet have a fixed list of devices.
 +
 Even if you do have a list, smart groups can also come in handy when your list is constantly being appended with new devices. Smart groups automatically group newly provisioned devices that match certain selection criteria.
 
@@ -13,21 +13,21 @@ Even if you do have a list, smart groups can also come in handy when your list i
 
 *To create a fixed group, follow these steps:*
 
-1.  Open the https://connect.ota.here.com/#/devices[Devices] tab and click *+Add group*.
-1.  Select *Fixed Group* and click Next.
-1.  In the next window, enter a group name.
-1.  Assign devices to your group.
+.  Open the https://connect.ota.here.com/#/devices[Devices] tab and click *+Add group*.
+.  Select *Fixed Group* and click Next.
+.  In the next window, enter a group name.
+.  Assign devices to your group.
 ..  If you have a list of devices that you want to put in your group, upload your list and click *Create*.
 +
 This list should be a `.txt` file with one ID on each line.
 +
 Before you upload this list, make sure that you've provisioned all of the specified devices first.
 +
-NOTE: By default, OTA Connect automatically generates device IDs during the provisioning process. Currently, there's no way to get a list of these IDs. However, to create this list, you need to know the device IDs for all the devices that you've provisioned. The best way to create this list is to have your developers xref:dev@ota-client::use-your-own-deviceid.adoc[define the device IDs] and keep a list of the IDs that they've configured. 
+NOTE: By default, OTA Connect automatically generates device IDs during the provisioning process. Currently, there's no way to get a list of these IDs. However, to create this list, you need to know the device IDs for all the devices that you've provisioned. The best way to create this list is to have your developers xref:dev@ota-client::use-your-own-deviceid.adoc[define the device IDs] and keep a list of the IDs that they've configured.
 +
 ..  If you don't have a list, you can add devices manually.
-+ 
-Click *Create* to finish creating your group, open the *All devices* or *Ungrouped devices* section, then drag and drop each device on to the group that you just created. 
++
+Click *Create* to finish creating your group, open the *All devices* or *Ungrouped devices* section, then drag and drop each device on to the group that you just created.
 
 
 // MC: Add animated gif and automate it
@@ -41,7 +41,7 @@ Click *Create* to finish creating your group, open the *All devices* or *Ungroup
 2.  Select *Smart Group* and click Next.
 3.  In the next window, enter a group name and define a filter for your devices.
 +
-A filter helps OTA Connect assign each vehicle to a fleet. Currently, OTA Connect can filter based on characters in the Device ID. By default OTA Connect generates a random device ID for you. But developers can xref:dev@ota-client::use-your-own-deviceid.adoc[configure the device ID] to be whatever you want. 
+A filter helps OTA Connect assign each vehicle to a fleet. Currently, OTA Connect can filter based on characters in the Device ID. By default OTA Connect generates a random device ID for you. But developers can xref:dev@ota-client::use-your-own-deviceid.adoc[configure the device ID] to be whatever you want.
 +
 In this procedure, we'll use the VIN number as an example of a device ID.
 +

--- a/ota-plus-web/docs/modules/ROOT/pages/create-provisioning-key.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/create-provisioning-key.adoc
@@ -1,4 +1,4 @@
-= Get a provisioning key
+== Get a provisioning key
 :page-partial:
 // tag::provisioning[]
 

--- a/ota-plus-web/docs/modules/ROOT/pages/device-page.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/device-page.adoc
@@ -32,12 +32,12 @@ image::s9-device_history.png[image]
 
 1.  Open the device details that we first looked at in *Step 3*.
 * Navigate to the https://connect.ota.here.com/#/devices[Devices] page, select a device group, and select a test device within that group.
-3.  Click the *primary ECU*, and in the *SOFTWARE* section, locate the software that you uploaded in the previous step.
+2.  Click the *primary ECU*, and in the *SOFTWARE* section, locate the software that you uploaded in the previous step.
 * If you uploaded two versions of the same software, you should see a row for each version that you uploaded.
-4.  Click the *first version* that you uploaded.
+3.  Click the *first version* that you uploaded.
 * In the right-hand *PROPERTIES* panel, you'll see more details about the selected software version — the status should be *Not Installed*.
 +
-5.  Click the *Install* button at the bottom of the *PROPERTIES* section.
+4.  Click the *Install* button at the bottom of the *PROPERTIES* section.
 * OTA Connect will remotely install the software on your test device.
 
 [.thumb]


### PR DESCRIPTION
This PR is to clean up some asciidoc syntax issues that were making antora barf up a bunch of warnings (and in some cases errors). That looks ugly on CI, and it also means that it's easy to miss a warning or error that we actually care about.

Mainly there were 3 issues:

### 1. Wrong numbers in ordered lists.
This comes from something that's a good practice in Markdown, but a bad habit in asciidoc. In asciidoc, you should either make an ordered list like this:
```
. some item
. something else
. item 3
```
or this:
```
1. some item
2. something else
3. item 3
```
The first option will automatically number the list for you, and you don't have to worry about it. The second option will also auto-number, but if the number you put is different that what got assigned with auto-numbering, it will throw a warning. This is actually good, because it catches errors like this, which would lead to both items being numbered 1, and asciidoctor throwing up a warning that you numbered item two wrong.
```
1. some item

There's an interesting detail about this item

2. something else
```
### 2. Unescaped attribute substitution

Asciidoc has a syntax for defining variables and then using them in the document, except that they're called attributes. You use an attribute by putting the attribute name in curly braces: `{some-attribute}`. If you put something in curly braces that isn't an attribute, you get a warning. You can fix this by escaping the first brace: `\{some-attribute}`

### 3. Heading levels in the wrong sequence

Markdown is lax about heading levels: you can start the page with a `###` section if you want, or put a `####` right after a `##` with no `###` in between. Asciidoc is pickier; your heading levels have to be strictly in order.