### PR TITLE
DOCS: Use resourceId for images

### DIFF
--- a/ota-plus-web/docs/modules/ROOT/pages/_partials/devices.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/_partials/devices.adoc
@@ -13,5 +13,5 @@
 * OTA Connect will remotely install the software version on your test device.
 
 [.thumb]
-image::s5-install_device.png[image]
+image::ota-web::s5-install_device.png[image]
 //  end::single-device-install-steps[]

--- a/ota-plus-web/docs/modules/ROOT/pages/create-device-groups.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/create-device-groups.adoc
@@ -23,7 +23,7 @@ This list should be a `.txt` file with one ID on each line.
 +
 Before you upload this list, make sure that you've provisioned all of the specified devices first.
 +
-NOTE: By default, OTA Connect automatically generates device IDs during the provisioning process. Currently, there's no way to get a list of these IDs. However, to create this list, you need to know the device IDs for all the devices that you've provisioned. The best way to create this list is to have your developers xref:dev@ota-client::use-your-own-deviceid.adoc[define the device IDs] and keep a list of the IDs that they've configured.
+NOTE: By default, OTA Connect automatically generates device IDs during the provisioning process. Currently, there's no way to get a list of these IDs. However, to create this list, you need to know the device IDs for all the devices that you've provisioned. The best way to create this list is to have your developers xref:ota-client::use-your-own-deviceid.adoc[define the device IDs] and keep a list of the IDs that they've configured.
 +
 ..  If you don't have a list, you can add devices manually.
 +
@@ -41,7 +41,7 @@ Click *Create* to finish creating your group, open the *All devices* or *Ungroup
 2.  Select *Smart Group* and click Next.
 3.  In the next window, enter a group name and define a filter for your devices.
 +
-A filter helps OTA Connect assign each vehicle to a fleet. Currently, OTA Connect can filter based on characters in the Device ID. By default OTA Connect generates a random device ID for you. But developers can xref:dev@ota-client::use-your-own-deviceid.adoc[configure the device ID] to be whatever you want.
+A filter helps OTA Connect assign each vehicle to a fleet. Currently, OTA Connect can filter based on characters in the Device ID. By default OTA Connect generates a random device ID for you. But developers can xref:ota-client::use-your-own-deviceid.adoc[configure the device ID] to be whatever you want.
 +
 In this procedure, we'll use the VIN number as an example of a device ID.
 +

--- a/ota-plus-web/docs/modules/ROOT/pages/create-provisioning-key.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/create-provisioning-key.adoc
@@ -6,13 +6,11 @@
 
 Go to the {app-url}/#/profile/access-keys[**Provisioning Keys**, window="_blank"] tab of your profile.
 
-image::s1-prov.png[]
-// MC: Images don't render from included files, copied this image to "ota-client" until I can find a better solution (this topic is included in ota-client:ROOT:download-prov-key.adoc)
+image::ota-web::s1-prov.png[]
 
 Create a new key, select its period of validity, and then download it.
 
-image::screenshot_provisioning_key_2.png[]
-// MC: Images don't render from included files, copied this image to "ota-client" until I can find a better solution (this topic is included in ota-client:ROOT:download-prov-key.adoc)
+image::ota-web::screenshot_provisioning_key_2.png[]
 
 It comes as a zip file containing a provisioning key and credentials for your build system to publish images. You don't need to unzip it; just save it somewhere. You'll need it when you set up your Yocto build or configure the {product-name} client.
 

--- a/ota-plus-web/docs/modules/ROOT/pages/index.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Introduction
 
-include::dev@getstarted::partial$product-intro.adoc[tags=standard-intro]
+include::getstarted::partial$product-intro.adoc[tags=standard-intro]
 
 == Who is this guide for?
 
-This guide is primarily intended for campaign managers who want an in-depth understanding of how to deploy software updates that their developers have prepared. You don't need any technical skills to follow these instructions, but helps if you already have some experience managing sofware deployments in the automotive industry.
+This guide is primarily intended for campaign managers who want an in-depth understanding of how to deploy software updates that their developers have prepared. You don't need any technical skills to follow these instructions, but helps if you already have some experience managing software deployments in the automotive industry.

--- a/ota-plus-web/docs/modules/ROOT/pages/manage-device-prov.adoc
+++ b/ota-plus-web/docs/modules/ROOT/pages/manage-device-prov.adoc
@@ -4,8 +4,8 @@ Before you can start working with devices, they need to provisioned with credent
 
 If you've just logged in and don't see any devices, ask your developers to provision some for you. Alternatively, if you feel comfortable with the Linux command line, you can provision devices yourself. The easiest way to provision a device is to simulate a device on your computer and have the OTA Connect server generate device credentials for you.
 
-The xref:dev@getstarted::simulate-device-workstation.adoc[get started] documentation describes how to do this in detail. If you want to try out this procedure, you'll need a provisioning key first. You can xref:create-provisioning-key.adoc[generate and download] this key from within the OTA Connect Portal.
+The xref:getstarted::simulate-device-workstation.adoc[get started] documentation describes how to do this in detail. If you want to try out this procedure, you'll need a provisioning key first. You can xref:create-provisioning-key.adoc[generate and download] this key from within the OTA Connect Portal.
 
-If you want understand how provisioning works in detail, have a look at the xref:dev@ota-client::client-provisioning-methods.adoc[Device Provisioning Methods] section of the OTA Connect Client guide.
+If you want understand how provisioning works in detail, have a look at the xref:ota-client::client-provisioning-methods.adoc[Device Provisioning Methods] section of the OTA Connect Client guide.
 
 // Note for client guide: Reprovisioning the same device wont override the old one, you need to delete the old one first.


### PR DESCRIPTION
As of Antora 2.1, images and attachments can use the same resourceId syntax as xrefs. This makes our lives easier, and means we no longer have to keep redundant copies of images in all the repos.