### PR TITLE
Add extra data to "recently created" endpoint

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
@@ -286,6 +286,13 @@ class CampaignerApi(val conf: Configuration, val apiExec: ApiClientExec)
       .withNamespace(Some(namespace))
       .execJsonValue(apiExec)
 
+  def countDevicesInCampaign(namespace: Namespace, campaignId: String)
+                            (implicit traceData: TraceData, ec: ExecutionContext): Future[JsValue] =
+    request(s"campaigns/$campaignId/stats")
+      .withNamespace(Some(namespace))
+      .execJsonValue(apiExec)
+      .map(j => (j \ "processed").as[JsValue])
+
   def recentUpdates(namespace: Namespace, limit: Int)(implicit traceData: TraceData): Future[JsValue] =
     request("updates")
       .transform(_.addQueryStringParameters("sortBy" -> "createdAt", "limit" -> limit.toString))

--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
@@ -300,6 +300,21 @@ class CampaignerApi(val conf: Configuration, val apiExec: ApiClientExec)
       .execJsonValue(apiExec)
 }
 
+class DirectorApi(val conf: Configuration, val apiExec: ApiClientExec)
+                 (implicit tracer: ZipkinTraceServiceLike) extends OtaPlusConfig with CirceJsonBodyWritables {
+
+  private def request(path: String)(implicit traceData: TraceData) =
+    ApiRequest.traced("director", directorApiUri.uri + "/api/v1/" + path)
+
+  def fetchEcuTypes(namespace: Namespace, updateId: String)
+                   (implicit traceData: TraceData, ec: ExecutionContext): Future[JsValue] =
+    request(s"multi_target_updates/$updateId")
+      .withNamespace(Some(namespace))
+      .execJson[JsObject](apiExec)
+      .map(_.keys.toSeq.sorted.map(JsString))
+      .map(JsArray(_))
+}
+
 class RepoServerApi(val conf: Configuration, val apiExec: ApiClientExec)(implicit tracer: ZipkinTraceServiceLike)
   extends OtaPlusConfig with CirceJsonBodyWritables {
 

--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
@@ -267,6 +267,11 @@ class DeviceRegistryApi(val conf: Configuration, val apiExec: ApiClientExec)
       .transform(_.addQueryStringParameters("sortBy" -> "createdAt", "limit" -> limit.toString))
       .withNamespace(Some(namespace))
       .execJsonValue(apiExec)
+
+  def countDevicesInGroup(namespace: Namespace, groupId: String)(implicit traceData: TraceData): Future[JsValue] =
+    request(s"device_groups/$groupId/count")
+      .withNamespace(Some(namespace))
+      .execJsonValue(apiExec)
 }
 
 class CampaignerApi(val conf: Configuration, val apiExec: ApiClientExec)

--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClientSupport.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClientSupport.scala
@@ -19,6 +19,8 @@ trait ApiClientSupport {
 
   val deviceRegistryApi = new DeviceRegistryApi(conf, clientExec)
 
+  val directorApi = new DirectorApi(conf, clientExec)
+
   val campaignerApi = new CampaignerApi(conf, clientExec)
 
   val repoServerApi = new RepoServerApi(conf, clientExec)

--- a/ota-plus-web/app/com/advancedtelematic/controllers/Data.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/Data.scala
@@ -9,9 +9,9 @@ import scala.collection.Seq
 
 object Data {
 
-  final case class FeedResource(createdAt: Instant, _type: String, resource: JsValue)
+  final case class FeedResource(createdAt: Instant, _type: String, resource: JsObject)
   object FeedResource {
-    def of(_type: String)(createdAt: Instant, resource: JsValue): FeedResource = {
+    def of(_type: String)(createdAt: Instant, resource: JsObject): FeedResource = {
       FeedResource(createdAt, _type, resource)
     }
   }
@@ -20,7 +20,7 @@ object Data {
 
   def feedResourceReads(_type: String): Reads[FeedResource] = (
     (__ \ "createdAt").read[Instant] and
-    __.read[JsValue]
+    __.read[JsObject]
   )(FeedResource.of(_type) _)
 
   def feedResourcesReads(_type: String): Reads[Seq[FeedResource]] = {


### PR DESCRIPTION
We want to show some new data in the "recently created" feed. Namely:
1. for device groups, how many devices are in the group.
1. for campaigns, how many devices where potential targets (i.e. the "processed" field in the campaign stats).
1. for updates, which ECU types are part of the update (i.e. the hardware IDs of all the multi-target updates corresponding to the update).

In all cases it was about enriching the results we already had with some new data fetched from other endpoints. For 3 I had to add a director client to fetch the multi-target updates.