### PR TITLE
Publish latest tag when building image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val dockerSettings = {
     daemonUserUid in Docker := None,
     daemonUser in Docker := "daemon",
     dockerRepository := Some("advancedtelematic"),
-    dockerUpdateLatest := false,
+    dockerUpdateLatest := true,
     dockerBaseImage := "advancedtelematic/alpine-jre:adoptopenjdk-jdk8u222",
     dockerAliases += dockerAlias.value.withTag(git.gitHeadCommit.value)
   )


### PR DESCRIPTION
Some systems need to know what is the latest container version. For
example HAT deployments.

CI using gitlab no longer pushes `artifacts.txt` to S3 as teamcity
did. So we need to push this tag to `:latest` so that services can use
the `latest` tag.