### PR TITLE
Build Docker image from branch `deploy/rome`.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ build docker image:
     - schedules
   only:
     - master
+    - deploy/rome
   tags:
     - docker-sock
   image: advancedtelematic/app-gitlab-job:0.0.1


### PR DESCRIPTION
FE devs are still using the old `rome` hat. TC used to build the Docker image from `deploy/rome` but it does it no more.