### PR TITLE
Adapt to the new format of the tentative_users endpoint

### DIFF
--- a/ota-plus-web/app/reactapp/src/components/profile/ProfileOrganization.jsx
+++ b/ota-plus-web/app/reactapp/src/components/profile/ProfileOrganization.jsx
@@ -222,7 +222,7 @@ class ProfileOrganization extends Component {
                 {organizationUsers.map((item, index) => (
                   <div className="organization-info" key={`organization-info-user-${index}`}>
                     <div className="column name" id="organization-name">
-                      {item}
+                      {item.email}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
Need some adjustment to show the tentative user emails after https://github.com/advancedtelematic/ota-plus-user-profile/pull/128, because before user-profile was returning
```
[ "a@test.com", "b@test.com" ]
```
but now it's returning
```
[ { email : "a@test.com", addedAt : "1970-01-01T00:00:00Z" } , { email : "b@test.com", addedAt : "1970-01-01T00:00:00Z" } ]
```
