### PR TITLE
Use new default organization endpoint.

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/ApiClient.scala
@@ -22,7 +22,7 @@ case class UserPass(user: String, pass: String)
 
 case class Feature(feature: FeatureName, client_id: Option[UUID], enabled: Boolean)
 
-case class UserOrganization(namespace: Namespace, name: String, isDefault: Boolean)
+case class UserOrganization(namespace: Namespace, name: String)
 
 object ApiRequest {
   case class UserOptions(token: Option[String] = None,

--- a/ota-plus-web/app/com/advancedtelematic/api/clients/UserProfileApi.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/clients/UserProfileApi.scala
@@ -35,9 +35,8 @@ class UserProfileApi(val conf: Configuration, val apiExec: ApiClientExec)(implic
   implicit val userOrganizationR: Reads[UserOrganization] = {
     (
       (__ \ "namespace").read[Namespace] and
-        (__ \ "name").read[String] and
-        (__ \ "isDefault").read[Boolean]
-      )(UserOrganization.apply _)
+      (__ \ "name").read[String]
+    )(UserOrganization.apply _)
   }
 
   def getUser(userId: UserId)(implicit traceData: TraceData): Future[JsValue] =

--- a/ota-plus-web/app/reactapp/src/config.js
+++ b/ota-plus-web/app/reactapp/src/config.js
@@ -27,6 +27,7 @@ export const API_USER_UPDATE = '/user/profile';
 export const API_USER_CHANGE_PASSWORD = '/user/change_password';
 export const API_USER_ACTIVE_DEVICE_COUNT = '/api/v1/active_device_count';
 export const API_USER_DEVICES_SEEN = '/api/v1/auditor/devices_seen_in';
+export const API_USER_DEFAULT_ORGANIZATION = '/user/organizations/default';
 export const API_USER_ORGANIZATIONS = '/user/organizations';
 export const API_USER_ORGANIZATIONS_SWITCH_NAMESPACE = '/organizations/$namespace/index';
 export const API_USER_ORGANIZATIONS_ADD_USER = '/organization/users';

--- a/ota-plus-web/app/reactapp/src/stores/UserStore.js
+++ b/ota-plus-web/app/reactapp/src/stores/UserStore.js
@@ -14,6 +14,7 @@ import {
   API_USER_ACTIVE_DEVICE_COUNT,
   API_USER_DEVICES_SEEN,
   API_USER_CONTRACTS,
+  API_USER_DEFAULT_ORGANIZATION,
   API_USER_ORGANIZATIONS,
   API_USER_ORGANIZATIONS_ADD_USER,
   API_USER_ORGANIZATIONS_GET_USERS,
@@ -102,7 +103,8 @@ export default class UserStore {
       if (namespaceCookie) {
         userOrganization = data.find(organization => organization.namespace === namespaceCookie);
       } else {
-        userOrganization = data.find(organization => organization.isDefault);
+        const { data } = await axios.get(API_USER_DEFAULT_ORGANIZATION);
+        userOrganization = data;
         Cookies.set(ORGANIZATION_NAMESPACE_COOKIE, userOrganization.namespace);
       }
       this.userOrganizationName = userOrganization.name;

--- a/ota-plus-web/test/com/advancedtelematic/controllers/GarageLoginSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/GarageLoginSpec.scala
@@ -93,7 +93,6 @@ class GarageLoginSpec extends PlaySpec with GuiceOneAppPerSuite with MockWSHelpe
         Json.obj(
         "namespace" -> namespace,
         "name" -> "My Organization",
-        "isDefault" -> true
       ))))
 
     case ("GET", url) if ".*/api/v1/users/.*".r.findFirstIn(url).isDefined =>

--- a/ota-plus-web/test/com/advancedtelematic/controllers/OrganizationControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/OrganizationControllerSpec.scala
@@ -31,7 +31,6 @@ class OrganizationControllerSpec extends PlaySpec
         Json.obj(
           "namespace" -> userAllowedNamespace,
           "name" -> "My Organization",
-          "isDefault" -> true
         ))))
   }
 


### PR DESCRIPTION
After https://github.com/advancedtelematic/ota-plus-user-profile/pull/133 `/user/organizations` will stop sending a `isDefault` flag with the organization details. That flag is kind of legacy and it doesn't make much sense to send it to filter a single organization out. Also removing it will make the BE for that endpoint a bit simpler. FE only needs to know the default on login, we can use a dedicated endpoint for that.