### PR TITLE
Create default namespace for EKS cluster.

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
+++ b/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
@@ -38,7 +38,7 @@ class NamespaceFromUserProfile @Inject()(val conf: Configuration,
     oidcGateway
       .getUserInfo(accessToken)
       .flatMap { ic =>
-        userProfileApi.createUser(userId, ic.name, ic.email)
+        userProfileApi.createUser(userId, ic.name, ic.email, None)
       }
 
   override def apply(tokens: Tokens): Future[Namespace] = {


### PR DESCRIPTION
The test environments automatically created on EKS rely on a
`default` namespace being available. The `NoLoginAction` will
take care of that so that we can spin test environments. Still
there is no authentication, we just check if the `default`
namespace is available and we created if it's not.