### PR TITLE
[OTA-4328] Increase Play max header size.

### DIFF
--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -24,7 +24,7 @@ play.ws.timeout.request = 15 minutes
 
 play.http.errorHandler = "OtaPlusErrorHandler"
 
-play.server.netty.maxHeaderSize = 10240
+play.server.netty.maxHeaderSize = 20480
 
 play.http.filters="OtaPlusFilters"
 


### PR DESCRIPTION
See the bugs OTA-4328 and OTA-4330.
Both are caused by the headers being too big.