### PR TITLE
[OTA-3654] Route blacklist to device-registry instead of ota-core

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/OtaPlusConfig.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/OtaPlusConfig.scala
@@ -7,8 +7,6 @@ case class OtaApiUri(serviceName: String, uri: String)
 trait OtaPlusConfig {
   val conf: Configuration
 
-  val coreApiUri = OtaApiUri("core", conf.underlying.getString("core.uri"))
-
   val resolverApiUri = OtaApiUri("resolver", conf.underlying.getString("resolver.uri"))
 
   val devicesApiUri = OtaApiUri("device-registry", conf.underlying.getString("deviceregistry.uri"))

--- a/ota-plus-web/app/com/advancedtelematic/controllers/Application.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/Application.scala
@@ -85,7 +85,7 @@ class Application @Inject() (ws: TraceWSClient,
   private def apiByPath(version: ApiVersion, path: String) : Option[OtaApiUri] = {
     val pathComponents = path.split("/").toList
 
-    val proxiedPrefixes = coreProxiedPrefixes orElse
+    val proxiedPrefixes =
       deviceRegistryProxiedPrefixes orElse
       resolverProxiedPrefixes orElse
       auditorProxiedPrefixes orElse
@@ -109,25 +109,13 @@ class Application @Inject() (ws: TraceWSClient,
     case (_, "assignments" :: _) => directorApiUri
   }
 
-  private val coreProxiedPrefixes: Dispatcher = {
-    case (_, "packages" :: _) => coreApiUri
-    case (_, "devices_info" :: _) => coreApiUri
-    case (_, "device_updates" :: _) => coreApiUri
-    case (_, "vehicle_updates" :: _) => coreApiUri
-    case (_, "update_requests" :: _) => coreApiUri
-    case (_, "history" :: _) => coreApiUri
-    case (_, "blacklist" :: _) => coreApiUri
-    case (_, "impact" :: _) => coreApiUri
-    case (ApiVersion.v1, "campaigns" :: _) => coreApiUri
-    case (_, "auto_install" :: _) => coreApiUri
-  }
-
   private val deviceRegistryProxiedPrefixes: Dispatcher = {
     case (_, "devices" :: _) => devicesApiUri
     case (_, "device_groups" :: _) => devicesApiUri
     case (_, "device_count" :: _) => devicesApiUri
     case (_, "active_device_count" :: _) => devicesApiUri
     case (_, "device_packages" :: _) => devicesApiUri
+    case (_, "package_lists" :: _) => devicesApiUri
   }
 
   private val resolverProxiedPrefixes: Dispatcher = {

--- a/ota-plus-web/app/reactapp/src/components/software/BlacklistModal.jsx
+++ b/ota-plus-web/app/reactapp/src/components/software/BlacklistModal.jsx
@@ -52,8 +52,6 @@ class BlacklistModal extends Component {
       if (newBlacklistAction.mode === 'edit') {
         softwareStore.fetchBlacklist();
         softwareStore.fetchBlacklistedPackage(data);
-      } else {
-        softwareStore.fetchAffectedDevicesCount(data);
       }
     }
   }

--- a/ota-plus-web/app/reactapp/src/config.js
+++ b/ota-plus-web/app/reactapp/src/config.js
@@ -102,12 +102,11 @@ export const API_SOFTWARE_COMMENTS = '/api/v1/user_repo/comments';
  */
 export const API_PACKAGES_COUNT_VERSION_BY_NAME = '/api/v1/device_packages';
 export const API_PACKAGES_COUNT_DEVICE_AND_GROUP = '/api/v1/device_count';
-export const API_PACKAGES_BLACKLIST_FETCH = '/api/v1/blacklist';
-export const API_PACKAGES_PACKAGE_BLACKLISTED_FETCH = '/api/v1/blacklist';
-export const API_PACKAGES_BLACKLIST = '/api/v1/blacklist';
-export const API_PACKAGES_UPDATE_BLACKLISTED = '/api/v1/blacklist';
-export const API_PACKAGES_REMOVE_FROM_BLACKLIST = '/api/v1/blacklist';
-export const API_PACKAGES_AFFECTED_DEVICES_COUNT_FETCH = '/api/v1/blacklist';
+export const API_PACKAGES_BLACKLIST_FETCH = '/api/v1/package_lists';
+export const API_PACKAGES_PACKAGE_BLACKLISTED_FETCH = '/api/v1/package_lists';
+export const API_PACKAGES_BLACKLIST = '/api/v1/package_lists';
+export const API_PACKAGES_UPDATE_BLACKLISTED = '/api/v1/package_lists';
+export const API_PACKAGES_REMOVE_FROM_BLACKLIST = '/api/v1/package_lists';
 
 /*
  *  Campaigns
@@ -131,11 +130,6 @@ export const API_CAMPAIGNS_LEGACY_CANCEL = '/api/v1/campaigns';
 export const API_CAMPAIGNS_CANCEL_REQUEST = '/api/v1/update_requests';
 export const API_CAMPAIGNS_STATISTICS_FAILURES_SINGLE = '/api/v1/devices';
 export const API_CAMPAIGNS_RETRY_SINGLE = '/api/v2/campaigns';
-
-/*
- *  Impact analysis
- */
-export const API_IMPACT_ANALYSIS_FETCH = '/api/v1/impact/blacklist';
 
 /*
  *  Provisioning

--- a/ota-plus-web/app/reactapp/src/pages/ImpactAnalysis.jsx
+++ b/ota-plus-web/app/reactapp/src/pages/ImpactAnalysis.jsx
@@ -17,9 +17,8 @@ class ImpactAnalysis extends Component {
 
   componentDidMount() {
     const { stores } = this.props;
-    const { softwareStore, impactAnalysisStore } = stores;
+    const { softwareStore } = stores;
     softwareStore.fetchBlacklist(true, true);
-    impactAnalysisStore.fetchImpactAnalysis();
   }
 
   render() {

--- a/ota-plus-web/app/reactapp/src/stores/ImpactAnalysisStore.js
+++ b/ota-plus-web/app/reactapp/src/stores/ImpactAnalysisStore.js
@@ -1,9 +1,7 @@
 /** @format */
 
 import { observable } from 'mobx';
-import axios from 'axios';
-import { API_IMPACT_ANALYSIS_FETCH } from '../config';
-import { resetAsync, handleAsyncSuccess, handleAsyncError } from '../utils/Common';
+import { resetAsync } from '../utils/Common';
 
 export default class ImpactAnalysisStore {
   @observable impactAnalysisFetchAsync = {};
@@ -14,20 +12,4 @@ export default class ImpactAnalysisStore {
     resetAsync(this.impactAnalysisFetchAsync);
   }
 
-  fetchImpactAnalysis() {
-    resetAsync(this.impactAnalysisFetchAsync, true);
-    return axios
-      .get(API_IMPACT_ANALYSIS_FETCH)
-      .then(
-        (response) => {
-          this.impactAnalysis = response.data;
-          this.impactAnalysisFetchAsync = handleAsyncSuccess(response);
-        },
-      )
-      .catch(
-        (error) => {
-          this.impactAnalysisFetchAsync = handleAsyncError(error);
-        },
-      );
-  }
 }

--- a/ota-plus-web/app/reactapp/src/stores/SoftwareStore.js
+++ b/ota-plus-web/app/reactapp/src/stores/SoftwareStore.js
@@ -13,7 +13,6 @@ import {
   API_PACKAGES_BLACKLIST,
   API_PACKAGES_UPDATE_BLACKLISTED,
   API_PACKAGES_REMOVE_FROM_BLACKLIST,
-  API_PACKAGES_AFFECTED_DEVICES_COUNT_FETCH,
   API_SOFTWARE_DEVICE_SOFTWARE,
   API_SOFTWARE_DEVICE_HISTORY,
   API_SOFTWARE_DIRECTOR_DEVICE_AUTO_INSTALL,
@@ -61,8 +60,6 @@ export default class SoftwareStore {
 
   @observable packagesRemoveFromBlacklistAsync = {};
 
-  @observable packagesAffectedDevicesCountFetchAsync = {};
-
   @observable packagesOndeviceFetchAsync = {};
 
   @observable packagesAutoInstalledFetchAsync = {};
@@ -98,8 +95,6 @@ export default class SoftwareStore {
   @observable preparedBlacklist = [];
 
   @observable blacklistedPackage = {};
-
-  @observable affectedDevicesCount = {};
 
   @observable autoInstalledPackages = [];
 
@@ -139,7 +134,6 @@ export default class SoftwareStore {
     resetAsync(this.packagesBlacklistAsync);
     resetAsync(this.packagesUpdateBlacklistedAsync);
     resetAsync(this.packagesRemoveFromBlacklistAsync);
-    resetAsync(this.packagesAffectedDevicesCountFetchAsync);
     resetAsync(this.packagesOndeviceFetchAsync);
     resetAsync(this.packagesAutoInstalledFetchAsync);
     resetAsync(this.packagesHistoryFetchAsync);
@@ -482,19 +476,6 @@ export default class SoftwareStore {
       })
       .catch((error) => {
         this.packagesRemoveFromBlacklistAsync = handleAsyncError(error);
-      });
-  }
-
-  fetchAffectedDevicesCount(data) {
-    resetAsync(this.packagesAffectedDevicesCountFetchAsync, true);
-    return axios
-      .get(`${API_PACKAGES_AFFECTED_DEVICES_COUNT_FETCH}/${data.name}/${data.version}/preview`)
-      .then((response) => {
-        this.affectedDevicesCount = response.data;
-        this.packagesAffectedDevicesCountFetchAsync = handleAsyncSuccess(response);
-      })
-      .catch((error) => {
-        this.packagesAffectedDevicesCountFetchAsync = handleAsyncError(error);
       });
   }
 
@@ -920,9 +901,7 @@ export default class SoftwareStore {
     resetAsync(this.packagesBlacklistAsync);
     resetAsync(this.packagesUpdateBlacklistedAsync);
     resetAsync(this.packagesRemoveFromBlacklistAsync);
-    resetAsync(this.packagesAffectedDevicesCountFetchAsync);
     this.blacklistedPackage = {};
-    this.affectedDevicesCount = {};
   }
 
   reset() {
@@ -935,7 +914,6 @@ export default class SoftwareStore {
     resetAsync(this.packagesBlacklistAsync);
     resetAsync(this.packagesUpdateBlacklistedAsync);
     resetAsync(this.packagesRemoveFromBlacklistAsync);
-    resetAsync(this.packagesAffectedDevicesCountFetchAsync);
     resetAsync(this.packagesAutoInstalledFetchAsync);
     resetAsync(this.packagesHistoryFetchAsync);
     resetAsync(this.packagesEnableAutoInstallAsync);
@@ -952,7 +930,6 @@ export default class SoftwareStore {
     this.preparedBlacklist = [];
     this.preparedBlacklistRaw = [];
     this.blacklistedPackage = {};
-    this.affectedDevicesCount = {};
     this.autoInstalledPackages = [];
     this.packagesHistory = [];
     this.ondevicePackages = [];

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -179,14 +179,6 @@ campaigner = {
   uri = ${campaigner.scheme}"://"${?campaigner.host}":"${?campaigner.port}
 }
 
-core = {
-  host = ${?SOTA_CORE_HOST}
-  port = ${?SOTA_CORE_PORT}
-  scheme = "http"
-  scheme = ${?SOTA_CORE_SCHEME}
-  uri = ${core.scheme}"://"${?core.host}":"${?core.port}
-}
-
 crypt {
   host = ${?CRYPT_HOST}
   port = ${?CRYPT_PORT}


### PR DESCRIPTION
This is part of the termination of the ota-core service.
Once https://github.com/advancedtelematic/ota-device-registry/pull/159 is merged and deployed device-registry will take care of the "blacklisting" feature.