### PR TITLE
[OTA-3955] Update the default organization when switching.

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/clients/UserProfileApi.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/clients/UserProfileApi.scala
@@ -88,11 +88,6 @@ class UserProfileApi(val conf: Configuration, val apiExec: ApiClientExec)(implic
           .withBody(body))
       .execResult(apiExec)
 
-  def userProfileRequest(userId: UserId, method: String, path: String)(implicit traceData: TraceData): Future[Result] =
-    userProfileRequest(s"users/${segment(userId.id)}/$path")
-      .transform(_.withMethod(method))
-      .execResult(apiExec)
-
   def userOrganizations(userId: UserId)(implicit traceData: TraceData): Future[Set[UserOrganization]] =
     userProfileRequest(s"users/${segment(userId.id)}/organizations")
       .transform(_.withMethod("GET"))
@@ -109,6 +104,18 @@ class UserProfileApi(val conf: Configuration, val apiExec: ApiClientExec)(implic
       .transform(_.addQueryStringParameters("limit" -> limit.toString))
       .withUser(userId)
       .execJsonValue(apiExec)
+
+  def setNewDefaultOrganization(userId: UserId, newNamespace: Namespace)
+                               (implicit traceData: TraceData): Future[Result] =
+    userProfileRequest(s"users/${segment(userId.id)}/organizations/default")
+      .transform(_.withMethod("PATCH"))
+      .transform(_.withBody(Json.obj("namespace" -> newNamespace.get)))
+      .execResult(apiExec)
+
+  def userProfileRequest(userId: UserId, method: String, path: String)(implicit traceData: TraceData): Future[Result] =
+    userProfileRequest(s"users/${segment(userId.id)}/$path")
+      .transform(_.withMethod(method))
+      .execResult(apiExec)
 
   def organizationRequest(namespace: Namespace,
                           userId: UserId,

--- a/ota-plus-web/app/com/advancedtelematic/controllers/OrganizationController.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/OrganizationController.scala
@@ -40,6 +40,7 @@ class OrganizationController @Inject()(val conf: Configuration,
           redirectToIndex
         case true =>
           log.info(s"User ${userId.id} switches to the namespace ${namespace.get}")
+          userProfileApi.setNewDefaultOrganization(userId, namespace)
           redirectToIndex.withSession(
             "namespace" -> namespace.get,
             "id_token" -> request.idToken.value,

--- a/ota-plus-web/test/com/advancedtelematic/controllers/OrganizationControllerSpec.scala
+++ b/ota-plus-web/test/com/advancedtelematic/controllers/OrganizationControllerSpec.scala
@@ -32,6 +32,8 @@ class OrganizationControllerSpec extends PlaySpec
           "namespace" -> userAllowedNamespace,
           "name" -> "My Organization",
         ))))
+    case (PATCH, url) if s"$userProfileUri/api/v1/users/.*/organizations".r.findFirstIn(url).isDefined =>
+      Action(_ => NoContent)
   }
 
   implicit override lazy val app: play.api.Application =


### PR DESCRIPTION
This will have the effect the the user will always land on the last
accessed organization, even if he logs out or gets logged out.