### PR TITLE
Remove unused resolver routes.

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/api/OtaPlusConfig.scala
+++ b/ota-plus-web/app/com/advancedtelematic/api/OtaPlusConfig.scala
@@ -7,8 +7,6 @@ case class OtaApiUri(serviceName: String, uri: String)
 trait OtaPlusConfig {
   val conf: Configuration
 
-  val resolverApiUri = OtaApiUri("resolver", conf.underlying.getString("resolver.uri"))
-
   val devicesApiUri = OtaApiUri("device-registry", conf.underlying.getString("deviceregistry.uri"))
 
   val authPlusApiUri = OtaApiUri("auth-plus", conf.underlying.getString("authplus.uri"))

--- a/ota-plus-web/app/com/advancedtelematic/controllers/Application.scala
+++ b/ota-plus-web/app/com/advancedtelematic/controllers/Application.scala
@@ -87,7 +87,6 @@ class Application @Inject() (ws: TraceWSClient,
 
     val proxiedPrefixes =
       deviceRegistryProxiedPrefixes orElse
-      resolverProxiedPrefixes orElse
       auditorProxiedPrefixes orElse
       directorProxiedPrefixes orElse
       repoProxiedPrefixes orElse
@@ -116,15 +115,6 @@ class Application @Inject() (ws: TraceWSClient,
     case (_, "active_device_count" :: _) => devicesApiUri
     case (_, "device_packages" :: _) => devicesApiUri
     case (_, "package_lists" :: _) => devicesApiUri
-  }
-
-  private val resolverProxiedPrefixes: Dispatcher = {
-    case (_, "resolver" :: _) => resolverApiUri
-    case (_, "firmware" :: _) => resolverApiUri
-    case (_, "filters" :: _) => resolverApiUri
-    case (_, "components" :: _) => resolverApiUri
-    case (_, "resolve" :: _) => resolverApiUri
-    case (_, "package_filters" :: _) => resolverApiUri
   }
 
   private val repoProxiedPrefixes: Dispatcher = {

--- a/ota-plus-web/conf/application.conf
+++ b/ota-plus-web/conf/application.conf
@@ -232,14 +232,6 @@ keyserver = {
   uri = ${keyserver.scheme}"://"${?keyserver.host}":"${?keyserver.port}
 }
 
-resolver = {
-  host = ${?SOTA_RESOLVER_HOST}
-  port = ${?SOTA_RESOLVER_PORT}
-  scheme = "http"
-  scheme = ${?SOTA_RESOLVER_SCHEME}
-  uri = ${resolver.scheme}"://"${?resolver.host}":"${?resolver.port}
-}
-
 api_gateway = {
   host = ${?API_GATEWAY_HOST}
   port = ${?API_GATEWAY_PORT}


### PR DESCRIPTION
Resolver is a service that doesn't exist anymore. This
old routes are not used anymore and can be cleaned up.