### PR TITLE
Remove unused NamespaceFromIdentity.

### DIFF
--- a/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
+++ b/ota-plus-web/app/com/advancedtelematic/auth/oidc/NamespaceProvider.scala
@@ -16,12 +16,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait NamespaceProvider extends (Tokens => Future[Namespace])
 
-class NamespaceFromIdentity extends NamespaceProvider {
-  override def apply(tokens: Tokens): Future[Namespace] = FastFuture.successful{
-    Namespace(tokens.idToken.userId.id)
-  }
-}
-
 class NamespaceFromUserProfile @Inject()(val conf: Configuration,
                                          val ws: WSClient,
                                          val clientExec: ApiClientExec,


### PR DESCRIPTION
This class was used when we used to have namespace = userId. But that
is not the case since f1be3c56 (see OTA-2618).
I can't imagine we'll ever want to support this case again, now that we have
the whole organizations/environments logic. Moreover, we're not using
this in any environment: I've checked the old hats, EKS and DEV/SIT/PRD.
So there's no use for this, and we can clean it up.